### PR TITLE
[SVS-5] Additional files for parametrized SonarQube rules are retrieved from the SonarQube quality profile

### DIFF
--- a/src/Integration.UnitTests/Binding/BindCommandTests.cs
+++ b/src/Integration.UnitTests/Binding/BindCommandTests.cs
@@ -366,12 +366,12 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             return testSubject;
         }
 
-        private class TestBindingWorkflow : IBindingWorkflow
+        private class TestBindingWorkflow : IBindingWorkflowExecutor
         {
             public ProjectViewModel BoundProject { get; private set; }
 
             #region IBindingWorkflow
-            void IBindingWorkflow.BindProject(ProjectViewModel projectVM)
+            void IBindingWorkflowExecutor.BindProject(ProjectViewModel projectVM)
             {
                 this.BoundProject = projectVM;
             }

--- a/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
+++ b/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
@@ -87,7 +87,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         }
 
         [TestMethod]
-        public void BindingWorkflow_DownloadRuleSet_Success()
+        public void BindingWorkflow_DownloadQualityProfile_Success()
         {
             // Setup
             BindingWorkflow testSubject = this.CreateTestSubject();
@@ -95,16 +95,20 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var notifications = new ConfigurableProgressStepExecutionEvents();
 
             RuleSet ruleSet = TestRuleSetHelper.CreateTestRuleSetWithRuleIds(new[] { "Key1", "Key2" });
-            RoslynExportProfile export = RoslynExportProfileHelper.CreateExport(ruleSet);
+            var nugetPackages = new[] { new PackageName("myPackageId", new SemanticVersion("1.0.0")) };
+            var additionalFiles = new[] { new AdditionalFile { FileName = "abc.xml", Content = new byte[] { 1, 2, 3 } } };
+            RoslynExportProfile export = RoslynExportProfileHelper.CreateExport(ruleSet, nugetPackages, additionalFiles);
 
             string language = "lang";
             this.ConfigureProfileExport(testSubject, export, language, RuleSetGroup.VB);
 
             // Act
-            testSubject.DownloadRuleSet(controller, CancellationToken.None, notifications, new[] { language });
+            testSubject.DownloadQualityProfile(controller, CancellationToken.None, notifications, new[] { language });
 
             // Verify
             RuleSetAssert.AreEqual(ruleSet, testSubject.Rulesets[RuleSetGroup.VB], "Unexpected rule set");
+            VerifyAdditionalFilesDownloaded(additionalFiles, testSubject);
+            VerifyNuGetPackgesDownloaded(nugetPackages, testSubject);
             this.outputWindowPane.AssertOutputStrings(0);
             controller.AssertNumberOfAbortRequests(0);
             notifications.AssertProgress(
@@ -112,13 +116,13 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
                 1.0,
                 1.0);
             notifications.AssertProgressMessages(
-                string.Format(CultureInfo.CurrentCulture, Strings.DownloadingRulesProgressMessage, language),
+                string.Format(CultureInfo.CurrentCulture, Strings.DownloadingQualityProfileProgressMessage, language),
                 string.Empty,
-                Strings.RuleSetDownloadedSuccessfulMessage);
+                Strings.QualityProfileDownloadedSuccessfulMessage);
         }
 
         [TestMethod]
-        public void BindingWorkflow_DownloadRuleSet_Failure()
+        public void BindingWorkflow_DownloadQualityProfile_Failure()
         {
             // Setup
             BindingWorkflow testSubject = this.CreateTestSubject();
@@ -127,7 +131,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             this.ConfigureProfileExport(testSubject, null, language, RuleSetGroup.VB);
 
             // Act
-            testSubject.DownloadRuleSet(controller, CancellationToken.None, new ConfigurableProgressStepExecutionEvents(), new[] { language });
+            testSubject.DownloadQualityProfile(controller, CancellationToken.None, new ConfigurableProgressStepExecutionEvents(), new[] { language });
 
             // Verify
             Assert.IsFalse(testSubject.Rulesets.ContainsKey(RuleSetGroup.VB), "Not expecting any rules for this language");
@@ -297,6 +301,44 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         }
 
         [TestMethod]
+        public void BindingWorkflow_UnpackAdditionalFiles()
+        {
+            // Setup
+            var testSubject = this.CreateTestSubject();
+            var progressEvents = new ConfigurableProgressStepExecutionEvents();
+
+            string solutionRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            string solutionFilePath = Path.Combine(solutionRoot, "Solution.sln");
+            ProjectMock project1 = new ProjectMock("project1");
+            ProjectMock project2 = new ProjectMock("project2");
+            SolutionMock solution = new SolutionMock(new DTEMock(), solutionFilePath);
+            this.projectSystemHelper.CurrentActiveSolution = solution;
+
+            var file1 = new AdditionalFile { FileName = "file1.xml", Content = new byte[] { 1, 2, 3 } };
+            var file2 = new AdditionalFile { FileName = "file2.xml", Content = new byte[] { 4, 5, 6 } };
+            testSubject.AdditionalFiles.Add(file1);
+            testSubject.AdditionalFiles.Add(file2);
+
+            string expectedFile1Path = Path.Combine(solutionRoot, Constants.SonarQubeManagedFolderName, file1.FileName);
+            string expectedFile2Path = Path.Combine(solutionRoot, Constants.SonarQubeManagedFolderName, file2.FileName);
+
+            // Act
+            testSubject.UnpackAdditionalFiles(new ConfigurableProgressController(), CancellationToken.None, progressEvents);
+
+            // Verify
+            Assert.IsTrue(File.Exists(expectedFile1Path), "File 1 was not written to the correct location");
+            Assert.IsTrue(File.Exists(expectedFile2Path), "File 2 was not written to the correct location");
+            CollectionAssert.AreEqual(file1.Content, File.ReadAllBytes(expectedFile1Path), "Unexpected file 1 content");
+            CollectionAssert.AreEqual(file2.Content, File.ReadAllBytes(expectedFile2Path), "Unexpected file 1 content");
+            progressEvents.AssertProgressMessages(
+                string.Format(CultureInfo.CurrentCulture, Strings.UnpackingAdditionalFile, file1.FileName),
+                string.Format(CultureInfo.CurrentCulture, Strings.UnpackingAdditionalFile, file2.FileName));
+            progressEvents.AssertProgress(
+                .5,
+                1.0);
+        }
+
+        [TestMethod]
         public void BindingWorkflow_PersistBinding()
         {
             // Setup
@@ -356,6 +398,33 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             this.sonarQubeService.ReturnExport[language] = export;
             testSubject.LanguageToGroupMapping[language] = group;
+        }
+
+        private static void VerifyNuGetPackgesDownloaded(IEnumerable<PackageName> expectedPackages, BindingWorkflow testSubject)
+        {
+            var expected = expectedPackages.ToArray();
+            var actual = testSubject.NuGetPackages.Select(x => new PackageName(x.Id, new SemanticVersion(x.Version))).ToArray();
+
+            Assert.AreEqual(expected.Length, actual.Length, "Different number of packages.");
+
+            for (int i = 0; i < expected.Length; i++)
+            {
+                Assert.IsTrue(expected[i].Equals(actual[i]), $"Packages are different at index {i}.");
+            }
+        }
+
+        private static void VerifyAdditionalFilesDownloaded(IEnumerable<AdditionalFile> expectedFiles, BindingWorkflow testSubject)
+        {
+            var expected = expectedFiles.ToArray();
+            var actual = testSubject.AdditionalFiles.ToArray();
+
+            Assert.AreEqual(expected.Length, actual.Length, "Different number of files.");
+
+            for (int i = 0; i < expected.Length; i++)
+            {
+                Assert.AreEqual(expected[i].FileName, actual[i].FileName, $"Files have different names at index {i}.");
+                CollectionAssert.AreEqual(expected[i].Content, actual[i].Content, $"Files have different content at index {i}.");
+            }
         }
 
         #endregion

--- a/src/Integration.UnitTests/Integration.UnitTests.csproj
+++ b/src/Integration.UnitTests/Integration.UnitTests.csproj
@@ -37,6 +37,7 @@
     <CodeAnalysisRuleSet>Integration.UnitTests.Release.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\Packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>

--- a/src/Integration/Binding/BindCommand.cs
+++ b/src/Integration/Binding/BindCommand.cs
@@ -18,9 +18,9 @@ using System.Linq;
 
 namespace SonarLint.VisualStudio.Integration.Binding
 {
-    internal class BindCommand : HostedCommandBase, IBindingWorkflow
+    internal class BindCommand : HostedCommandBase, IBindingWorkflowExecutor
     {
-        private readonly IBindingWorkflow workflow;
+        private readonly IBindingWorkflowExecutor workflow;
         private readonly IProjectSystemHelper projectSystemHelper;
 
         public BindCommand(ConnectSectionController controller, ISonarQubeServiceWrapper sonarQubeService)
@@ -28,7 +28,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
         {
         }
 
-        internal /*for testing purposes*/ BindCommand(ConnectSectionController controller, ISonarQubeServiceWrapper sonarQubeService, IBindingWorkflow workflow, IProjectSystemHelper projectSystemHelper)
+        internal /*for testing purposes*/ BindCommand(ConnectSectionController controller, ISonarQubeServiceWrapper sonarQubeService, IBindingWorkflowExecutor workflow, IProjectSystemHelper projectSystemHelper)
             : base(controller)
         {
             if (sonarQubeService == null)
@@ -107,7 +107,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
         #region IBindingWorkflow
 
-        void IBindingWorkflow.BindProject(ProjectViewModel projectVM)
+        void IBindingWorkflowExecutor.BindProject(ProjectViewModel projectVM)
         {
             BindingWorkflow workflowExecutor = new BindingWorkflow(this, projectVM.ProjectInformation);
             IProgressEvents progressEvents = workflowExecutor.Run();

--- a/src/Integration/Binding/BindingWorkflow.cs
+++ b/src/Integration/Binding/BindingWorkflow.cs
@@ -5,6 +5,8 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using EnvDTE;
+using EnvDTE80;
 using Microsoft.Alm.Authentication;
 using Microsoft.VisualStudio.CodeAnalysis.RuleSets;
 using SonarLint.VisualStudio.Integration.Persistence;
@@ -72,6 +74,11 @@ namespace SonarLint.VisualStudio.Integration.Binding
             get;
         } = new List<NuGetPackageInfo>();
 
+        public List<AdditionalFile> AdditionalFiles
+        {
+            get;
+        } = new List<AdditionalFile>();
+
         public Dictionary<RuleSetGroup, string> SolutionRulesetPaths
         {
             get;
@@ -133,13 +140,16 @@ namespace SonarLint.VisualStudio.Integration.Binding
                         (token, notifications) => this.VerifyServerPlugins(controller, token, notifications)),
 
                 new ProgressStepDefinition(Strings.BindingProjectsDisplayMessage, StepAttributes.BackgroundThread,
-                        (token, notifications) => this.DownloadRuleSet(controller, token, notifications, languages)),
+                        (token, notifications) => this.DownloadQualityProfile(controller, token, notifications, languages)),
 
                 new ProgressStepDefinition(null, IndeterminateNonCancellableUIStep,
                         (token, notifications) => { NuGetHelper.LoadService(this.owner.ServiceProvider); /*The service needs to be loaded on UI thread*/ }),
 
                 new ProgressStepDefinition(Strings.BindingProjectsDisplayMessage, StepAttributes.BackgroundThread,
                         (token, notifications) => this.InstallPackages(controller, token, notifications)),
+
+                new ProgressStepDefinition(Strings.BindingProjectsDisplayMessage, StepAttributes.BackgroundThread,
+                        (token, notifications) => this.UnpackAdditionalFiles(controller, token, notifications)),
 
                 new ProgressStepDefinition(Strings.BindingProjectsDisplayMessage, IndeterminateNonCancellableUIStep,
                         (token, notifications) => this.PrepareRuleSetInjector(controller, notifications)),
@@ -171,7 +181,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
             }
         }
 
-        internal /*for testing purposes*/ void DownloadRuleSet(IProgressController controller, CancellationToken cancellationToken, IProgressStepExecutionEvents notificationEvents, IEnumerable<string> languages)
+        internal /*for testing purposes*/ void DownloadQualityProfile(IProgressController controller, CancellationToken cancellationToken, IProgressStepExecutionEvents notificationEvents, IEnumerable<string> languages)
         {
             Debug.Assert(controller != null);
             Debug.Assert(notificationEvents != null);
@@ -182,7 +192,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
             foreach (var language in languages)
             {
-                notifier.NotifyCurrentProgress(string.Format(CultureInfo.CurrentCulture, Strings.DownloadingRulesProgressMessage, language));
+                notifier.NotifyCurrentProgress(string.Format(CultureInfo.CurrentCulture, Strings.DownloadingQualityProfileProgressMessage, language));
 
                 var export = this.owner.SonarQubeService.GetExportProfile(this.project, language, cancellationToken);
 
@@ -193,6 +203,8 @@ namespace SonarLint.VisualStudio.Integration.Binding
                 }
 
                 this.NuGetPackages.AddRange(export.Deployment.NuGetPackages);
+
+                this.AdditionalFiles.AddRange(export.Configuration.AdditionalFiles);
 
                 var tempRuleSetFilePath = Path.GetTempFileName();
                 File.WriteAllText(tempRuleSetFilePath, export.Configuration.RuleSet.OuterXml);
@@ -209,7 +221,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
             if (failed)
             {
-                VsShellUtils.WriteToGeneralOutputPane(this.owner.ServiceProvider, Strings.RuleSetDownloadFailedMessage);
+                VsShellUtils.WriteToGeneralOutputPane(this.owner.ServiceProvider, Strings.QualityProfileDownloadFailedMessage);
                 bool aborted = controller.TryAbort();
                 Debug.Assert(aborted || cancellationToken.IsCancellationRequested, "Failed to abort the workflow");
             }
@@ -221,7 +233,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
                     this.Rulesets[this.LanguageToGroup(keyValue.Key)] = keyValue.Value;
                 }
 
-                notifier.NotifyCurrentProgress(Strings.RuleSetDownloadedSuccessfulMessage);
+                notifier.NotifyCurrentProgress(Strings.QualityProfileDownloadedSuccessfulMessage);
             }
         }
 
@@ -319,10 +331,45 @@ namespace SonarLint.VisualStudio.Integration.Binding
             }
         }
 
+        internal /*for testing purposes*/ void UnpackAdditionalFiles(IProgressController controller, CancellationToken token, IProgressStepExecutionEvents notificationEvents)
+        {
+            if (!this.AdditionalFiles.Any())
+            {
+                return; // Nothing to unpack
+            }
+
+            Solution2 solution = this.projectSystemHelper.GetCurrentActiveSolution();
+            if (solution == null)
+            {
+                VsShellUtils.WriteToGeneralOutputPane(this.owner.ServiceProvider, Strings.FailedToUnpackAdditionalFiles);
+                bool aborted = controller.TryAbort();
+                Debug.Assert(aborted || token.IsCancellationRequested, "Failed to abort the workflow");
+            }
+
+            string solutionRoot = Path.GetDirectoryName(solution.FullName);
+            string root = this.solutionRuleSetWriter.GetOrCreateRuleSetDirectory(PathHelper.ForceDirectoryEnding(solutionRoot));
+
+            DeterminateStepProgressNotifier notifier = new DeterminateStepProgressNotifier(notificationEvents, this.AdditionalFiles.Count());
+
+            foreach (var additionalFile in this.AdditionalFiles)
+            {
+                if (token.IsCancellationRequested)
+                {
+                    break;
+                }
+
+                string message = string.Format(CultureInfo.CurrentCulture, Strings.UnpackingAdditionalFile, additionalFile.FileName);
+                notifier.NotifyIncrementedProgress(message);
+
+                string filePath = Path.Combine(root, additionalFile.FileName);
+                File.WriteAllBytes(filePath, additionalFile.Content);
+            }
+        }
+
         internal /*for testing purposes*/ string SetSolutionRuleSet(RuleSetGroup group, string solutionFullPath)
         {
             Debug.Assert(!string.IsNullOrWhiteSpace(solutionFullPath), "Expecting a solution file path");
-            Debug.Assert(this.Rulesets.ContainsKey(group) && this.Rulesets[group] != null, $"Rule set should have been stashed by previous step ({nameof(DownloadRuleSet)})");
+            Debug.Assert(this.Rulesets.ContainsKey(group) && this.Rulesets[group] != null, $"Rule set should have been stashed by previous step ({nameof(DownloadQualityProfile)})");
 
             RuleSet ruleset;
             string path = null;
@@ -338,7 +385,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
         internal /*for testing purposes*/ string UpdateProjectRuleSet(RuleSetGroup group, string projectFullPath, string configurationName, string currentRuleSet)
         {
             Debug.Assert(!string.IsNullOrWhiteSpace(projectFullPath), "Expecting a project full path");
-            Debug.Assert(this.SolutionRulesetPaths.ContainsKey(group) && this.SolutionRulesetPaths[group] != null, $"Rule set should have been stashed by previous step ({nameof(DownloadRuleSet)})");
+            Debug.Assert(this.SolutionRulesetPaths.ContainsKey(group) && this.SolutionRulesetPaths[group] != null, $"Rule set should have been stashed by previous step ({nameof(DownloadQualityProfile)})");
 
             string solutionRuleSetPath = null;
             string projectRuleSetPath = null;

--- a/src/Integration/Binding/BindingWorkflow.cs
+++ b/src/Integration/Binding/BindingWorkflow.cs
@@ -21,7 +21,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using System.Xml;
 
 namespace SonarLint.VisualStudio.Integration.Binding
 {

--- a/src/Integration/Binding/IBindingWorkflowExecutor.cs
+++ b/src/Integration/Binding/IBindingWorkflowExecutor.cs
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------
-// <copyright file="IBindingWorkflow.cs" company="SonarSource SA and Microsoft Corporation">
+// <copyright file="IBindingWorkflowExecutor.cs" company="SonarSource SA and Microsoft Corporation">
 //   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
 //   Licensed under the MIT License. See License.txt in the project root for license information.
 // </copyright>
@@ -10,7 +10,7 @@ using SonarLint.VisualStudio.Integration.TeamExplorer;
 namespace SonarLint.VisualStudio.Integration.Binding
 {
     // Test only interface
-    internal interface  IBindingWorkflow
+    internal interface  IBindingWorkflowExecutor
     {
         void BindProject(ProjectViewModel projectVM);
     }

--- a/src/Integration/Binding/SolutionRuleSetWriter.cs
+++ b/src/Integration/Binding/SolutionRuleSetWriter.cs
@@ -81,7 +81,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
         /// <summary>
         /// Ensure that the solution level SonarQube rule set folder exists and return the full path to it.
         /// </summary>
-        internal /* testing purposes */ string GetOrCreateRuleSetDirectory(string solutionRoot)
+        public string GetOrCreateRuleSetDirectory(string solutionRoot)
         {
             string ruleSetDirectoryPath = Path.Combine(solutionRoot, Constants.SonarQubeManagedFolderName);
             if (!this.FileSystem.DirectoryExists(ruleSetDirectoryPath))

--- a/src/Integration/Binding/SolutionRuleSetWriter.cs
+++ b/src/Integration/Binding/SolutionRuleSetWriter.cs
@@ -53,7 +53,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
             }
 
             string solutionRoot = Path.GetDirectoryName(solutionFullPath);
-            string ruleSetRoot = this.GetOrCreateRuleSetDirectory(PathHelper.ForceDirectoryEnding(solutionRoot));
+            string ruleSetRoot = this.GetOrCreateRuleSetDirectory(solutionRoot);
 
             // Create or overwrite existing rule set
             string existingRuleSetPath = GenerateSolutionRuleSetPath(ruleSetRoot, this.projectInformation, fileNameSuffix);

--- a/src/Integration/Constants.cs
+++ b/src/Integration/Constants.cs
@@ -24,5 +24,9 @@ namespace SonarLint.VisualStudio.Integration
         /// </summary>
         public const string RuleSetName = "SonarQube";
 
+        /// <summary>
+        /// The property key which corresponds to the Roslyn analyzer additional files
+        /// </summary>
+        public const string AdditionalFilePropertyKey = "AdditionalFile";
     }
 }

--- a/src/Integration/IProjectSystemHelper.cs
+++ b/src/Integration/IProjectSystemHelper.cs
@@ -26,5 +26,7 @@ namespace SonarLint.VisualStudio.Integration
         void AddFileToProject(Project project, string file);
 
         IEnumerable<Project> GetSolutionManagedProjects();
+
+        Microsoft.Build.Evaluation.Project GetEquivalentMSBuildProject(EnvDTE.Project project);
     }
 }

--- a/src/Integration/IProjectSystemHelper.cs
+++ b/src/Integration/IProjectSystemHelper.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using EnvDTE;
+using EnvDTE80;
 using System;
 using System.Collections.Generic;
 
@@ -15,6 +16,8 @@ namespace SonarLint.VisualStudio.Integration
     internal interface IProjectSystemHelper
     {
         IServiceProvider ServiceProvider { get; }
+
+        Solution2 GetCurrentActiveSolution();
 
         Project GetSolutionItemsProject();
 

--- a/src/Integration/Integration.csproj
+++ b/src/Integration/Integration.csproj
@@ -125,7 +125,7 @@
     <Compile Include="Constants.cs" />
     <Compile Include="HostedCommandBase.cs" />
     <Compile Include="Binding\BindingWorkflow.cs" />
-    <Compile Include="Binding\IBindingWorkflow.cs" />
+    <Compile Include="Binding\IBindingWorkflowExecutor.cs" />
     <Compile Include="IProjectSystemHelper.cs" />
     <Compile Include="IActiveSolutionTracker.cs" />
     <Compile Include="IServiceProviderExtensions.cs" />

--- a/src/Integration/Integration.csproj
+++ b/src/Integration/Integration.csproj
@@ -33,6 +33,7 @@
     <CodeAnalysisRuleSet>Integration.Release.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=2.20.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\Packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.20.301151232\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
       <Private>True</Private>

--- a/src/Integration/ProjectSystemHelper.cs
+++ b/src/Integration/ProjectSystemHelper.cs
@@ -112,14 +112,21 @@ namespace SonarLint.VisualStudio.Integration
             }
         }
 
+        public Solution2 GetCurrentActiveSolution()
+        {
+            DTE dte = this.serviceProvider.GetService(typeof(DTE)) as DTE;
+            Debug.Assert(dte != null, "Could not find the DTE service");
+
+            Solution2 solution = (Solution2)dte?.Solution;
+
+            return solution;
+        }
+
         public Project GetSolutionItemsProject()
         {
             string solutionItemsFolderName = GetSolutionItemsFolderName(this.serviceProvider);
 
-            DTE dte = this.serviceProvider.GetService(typeof(DTE)) as DTE;
-            Debug.Assert(dte != null, "Could not find the DTE service");
-
-            Solution2 solution = (Solution2)dte.Solution;
+            Solution2 solution = this.GetCurrentActiveSolution();
 
             Project solutionItemsProject = null;
             // Enumerating instead of using OfType<Project> due to a bug in

--- a/src/Integration/ProjectSystemHelper.cs
+++ b/src/Integration/ProjectSystemHelper.cs
@@ -12,7 +12,6 @@ using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 
 namespace SonarLint.VisualStudio.Integration
@@ -194,6 +193,12 @@ namespace SonarLint.VisualStudio.Integration
         private static bool IsProjectKind(Project project, string projectKindGuidString)
         {
             return StringComparer.OrdinalIgnoreCase.Equals(projectKindGuidString, project.Kind);
+        }
+
+        public Microsoft.Build.Evaluation.Project GetEquivalentMSBuildProject(Project project)
+        {
+            return Microsoft.Build.Evaluation.ProjectCollection.GlobalProjectCollection
+                .LoadedProjects.FirstOrDefault(p => StringComparer.OrdinalIgnoreCase.Equals(p.FullPath, project.FullName));
         }
     }
 }

--- a/src/Integration/Resources/Strings.Designer.cs
+++ b/src/Integration/Resources/Strings.Designer.cs
@@ -260,11 +260,11 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Download rules for language &apos;{0}&apos;.
+        ///   Looks up a localized string similar to Download quality profile for language &apos;{0}&apos;.
         /// </summary>
-        public static string DownloadingRulesProgressMessage {
+        public static string DownloadingQualityProfileProgressMessage {
             get {
-                return ResourceManager.GetString("DownloadingRulesProgressMessage", resourceCulture);
+                return ResourceManager.GetString("DownloadingQualityProfileProgressMessage", resourceCulture);
             }
         }
         
@@ -338,6 +338,15 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         public static string FailedToToBindSolution {
             get {
                 return ResourceManager.GetString("FailedToToBindSolution", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to unpack additional files required for analyzers.
+        /// </summary>
+        public static string FailedToUnpackAdditionalFiles {
+            get {
+                return ResourceManager.GetString("FailedToUnpackAdditionalFiles", resourceCulture);
             }
         }
         
@@ -459,6 +468,24 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to SonarQube quality profile was downloaded successfully.
+        /// </summary>
+        public static string QualityProfileDownloadedSuccessfulMessage {
+            get {
+                return ResourceManager.GetString("QualityProfileDownloadedSuccessfulMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SonarQube quality profile: Failed to download profile.
+        /// </summary>
+        public static string QualityProfileDownloadFailedMessage {
+            get {
+                return ResourceManager.GetString("QualityProfileDownloadFailedMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Refresh.
         /// </summary>
         public static string RefreshCommandDisplayText {
@@ -486,25 +513,7 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to SonarQube rule set was downloaded successfully.
-        /// </summary>
-        public static string RuleSetDownloadedSuccessfulMessage {
-            get {
-                return ResourceManager.GetString("RuleSetDownloadedSuccessfulMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to SonarQube rule set: Failed to download rule set.
-        /// </summary>
-        public static string RuleSetDownloadFailedMessage {
-            get {
-                return ResourceManager.GetString("RuleSetDownloadFailedMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Generating rule sets.
+        ///   Looks up a localized string similar to Generating project rule sets.
         /// </summary>
         public static string RuleSetGenerationProgressMessage {
             get {
@@ -663,6 +672,15 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         public static string UnexpectedWorkflowError {
             get {
                 return ResourceManager.GetString("UnexpectedWorkflowError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unpacking additional file: {0}.
+        /// </summary>
+        public static string UnpackingAdditionalFile {
+            get {
+                return ResourceManager.GetString("UnpackingAdditionalFile", resourceCulture);
             }
         }
         

--- a/src/Integration/Resources/Strings.resx
+++ b/src/Integration/Resources/Strings.resx
@@ -221,13 +221,13 @@ Localization note: '[try again]()' is a special markup used to translate the tex
     <value>Binding projects</value>
     <comment>Display message</comment>
   </data>
-  <data name="RuleSetDownloadFailedMessage" xml:space="preserve">
-    <value>SonarQube rule set: Failed to download rule set</value>
-    <comment>Output window message indicating the rule set file failed to download</comment>
+  <data name="QualityProfileDownloadFailedMessage" xml:space="preserve">
+    <value>SonarQube quality profile: Failed to download profile</value>
+    <comment>Output window message indicating the quality profile file failed to download</comment>
   </data>
-  <data name="RuleSetDownloadedSuccessfulMessage" xml:space="preserve">
-    <value>SonarQube rule set was downloaded successfully</value>
-    <comment>Output window message indicating the rule set file was successfully downloaded</comment>
+  <data name="QualityProfileDownloadedSuccessfulMessage" xml:space="preserve">
+    <value>SonarQube quality profile was downloaded successfully</value>
+    <comment>Output window message indicating the quality profile was successfully downloaded</comment>
   </data>
   <data name="RuleSetDescription" xml:space="preserve">
     <value>Rule set generated from SonarQube</value>
@@ -270,7 +270,7 @@ Localization note: '[try again]()' is a special markup used to translate the tex
     <comment>Tool tip text to be displayed for the connected SonarQube server in the Team Explorer tree view when there are no SonarQube Projects available under the given server</comment>
   </data>
   <data name="RuleSetGenerationProgressMessage" xml:space="preserve">
-    <value>Generating rule sets</value>
+    <value>Generating project rule sets</value>
     <comment>A progress notification message</comment>
   </data>
   <data name="EnsuringNugetPackagesProgressMessage" xml:space="preserve">
@@ -355,8 +355,8 @@ ocalization note: '[try again]()' is a special markup used to translate the text
     <value>Hide unbound projects</value>
     <comment>Server context menu command display text to show all projects (inc. unbound projects)</comment>
   </data>
-  <data name="DownloadingRulesProgressMessage" xml:space="preserve">
-    <value>Download rules for language '{0}'</value>
+  <data name="DownloadingQualityProfileProgressMessage" xml:space="preserve">
+    <value>Download quality profile for language '{0}'</value>
     <comment>A progress notification message. {0} language name.</comment>
   </data>
   <data name="AutomationServerDescription" xml:space="preserve">
@@ -404,5 +404,13 @@ Localization note: '[Don't warn me again]()' is a special markup used to transla
   <data name="ServerDoesNotHaveCorrectVersionOfCSharpPlugin" xml:space="preserve">
     <value>SonarQube project binding failed: The server does not have the minimum required version ({0}) of the C# plugin installed.</value>
     <comment>Error message indicating that the server does not have the required version of the C# plugin installed. {0} minimum required version</comment>
+  </data>
+  <data name="FailedToUnpackAdditionalFiles" xml:space="preserve">
+    <value>Failed to unpack additional files required for analyzers</value>
+    <comment>Output window message indicating failure when unpacking additional files for analyzers</comment>
+  </data>
+  <data name="UnpackingAdditionalFile" xml:space="preserve">
+    <value>Unpacking additional file: {0}</value>
+    <comment>Progress message indicating an additional files is being unpacked. {0} additional file name</comment>
   </data>
 </root>

--- a/src/Integration/VsShellUtils.cs
+++ b/src/Integration/VsShellUtils.cs
@@ -89,5 +89,10 @@ namespace SonarLint.VisualStudio.Integration
                 .Where(p => StringComparer.OrdinalIgnoreCase.Equals(p.Name, propertyName))
                 .SingleOrDefault();
         }
+
+        internal static IEnumerable<Property> EnumerateProjectProperties(Project project, object additionalFilePropertyKey)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/TestInfrastructure/Framework/ConfigurableVsProjectSystemHelper.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableVsProjectSystemHelper.cs
@@ -6,7 +6,6 @@
 //-----------------------------------------------------------------------
 
 using EnvDTE;
-using SonarLint.VisualStudio.Integration;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -17,6 +16,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
     internal class ConfigurableVsProjectSystemHelper : IProjectSystemHelper
     {
         private readonly IServiceProvider serviceProvider;
+
+        public IDictionary<Project, Microsoft.Build.Evaluation.Project> MsBuildProjectMapping { get; } = new Dictionary<Project, Microsoft.Build.Evaluation.Project>();
 
         public ConfigurableVsProjectSystemHelper(IServiceProvider serviceProvider)
         {
@@ -59,6 +60,16 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         Solution2 IProjectSystemHelper.GetCurrentActiveSolution()
         {
             return this.CurrentActiveSolution;
+        }
+
+        Microsoft.Build.Evaluation.Project IProjectSystemHelper.GetEquivalentMSBuildProject(EnvDTE.Project project)
+        {
+            if (this.MsBuildProjectMapping.ContainsKey(project))
+            {
+                return this.MsBuildProjectMapping[project];
+            }
+
+            return null;
         }
 
         #endregion

--- a/src/TestInfrastructure/Framework/ConfigurableVsProjectSystemHelper.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableVsProjectSystemHelper.cs
@@ -10,6 +10,7 @@ using SonarLint.VisualStudio.Integration;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using EnvDTE80;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests
 {
@@ -54,6 +55,12 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
                 project.ProjectItems.AddFromFile(file);
             }
         }
+
+        Solution2 IProjectSystemHelper.GetCurrentActiveSolution()
+        {
+            return this.CurrentActiveSolution;
+        }
+
         #endregion
 
         #region Test helpers
@@ -63,6 +70,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         public IEnumerable<Project> ManagedProjects { get; set; }
 
         public Func<Project, string, bool> IsFileInProjectAction { get; set; }
+
+        public Solution2 CurrentActiveSolution { get; set; }
 
         #endregion
     }

--- a/src/TestInfrastructure/Helpers/RoslynExportProfileHelper.cs
+++ b/src/TestInfrastructure/Helpers/RoslynExportProfileHelper.cs
@@ -12,6 +12,7 @@ using SonarLint.VisualStudio.Integration.Service;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
+using System;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests
 {
@@ -24,6 +25,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
         public static RoslynExportProfile CreateExport(RuleSet ruleSet, IEnumerable<PackageName> packages)
         {
+            return CreateExport(ruleSet, Enumerable.Empty<PackageName>(), Enumerable.Empty<AdditionalFile>());
+        }
+
+        public static RoslynExportProfile CreateExport(RuleSet ruleSet, IEnumerable<PackageName> packages, IEnumerable<AdditionalFile> additionalFiles)
+        {
             string xml = TestRuleSetHelper.RuleSetToXml(ruleSet);
             var ruleSetXmlDoc = new XmlDocument();
             ruleSetXmlDoc.LoadXml(xml);
@@ -33,7 +39,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
                 Configuration = new Configuration
                 {
                     RuleSet = ruleSetXmlDoc.DocumentElement,
-                    AdditionalFiles = new List<AdditionalFile>()
+                    AdditionalFiles = additionalFiles.ToList()
                 },
                 Deployment = new Deployment
                 {

--- a/src/TestInfrastructure/TestInfrastructure.csproj
+++ b/src/TestInfrastructure/TestInfrastructure.csproj
@@ -32,6 +32,7 @@
     <CodeAnalysisRuleSet>TestInfrastructure.Release.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\Packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
       <Private>True</Private>

--- a/src/TestInfrastructure/VsObjectModelMocks/SolutionMock.Solution2.cs
+++ b/src/TestInfrastructure/VsObjectModelMocks/SolutionMock.Solution2.cs
@@ -23,6 +23,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             : base(solutionFile)
         {
             this.dte = dte;
+            if (this.dte != null)
+            {
+                this.dte.Solution = this;
+            }
         }
 
         DTE Solution2.DTE

--- a/src/TestInfrastructure/VsObjectModelMocks/SolutionMock.cs
+++ b/src/TestInfrastructure/VsObjectModelMocks/SolutionMock.cs
@@ -25,7 +25,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             : base("Solution.sln")
         {
             this.dte = dte;
-            if (dte!=null)
+            if (dte != null)
             {
                 dte.Solution = this;
             }


### PR DESCRIPTION
Added an extra step in the BindingWorkflow to unpack the additional files (if any) that are downloaded with the quality profile export XML. Additional files are unpacked under the SonarQube folder, alongside the solution level rule set file.
Also renamed the IBindingWorkflow interface to IBindingWorkflowExecutor in order to better reflect what it actually does (similar to the IConnectionWorkflowExec..). With the previous name, it was strange to have BindCommand implement IBindingWorkflow, but BindingWorkflow NOT implement IBindingWorkflow.