### PR TITLE
Fix use of environment variables

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
   solution_path: src\SonarLint.VisualStudio.Integration.sln
 
 before_build:
-  - cmd: nuget restore $(solution_path)
+  - cmd: nuget restore %solution_path%
 
 build:
   verbosity: minimal


### PR DESCRIPTION
Use correct syntax for command prompt environment variables %NAME% rather than MSBuild style $(NAME)