### PR TITLE
[SVS-24] Extract the transferable state into a separate cls

### DIFF
--- a/src/Integration.UnitTests/Binding/BindCommandTests.cs
+++ b/src/Integration.UnitTests/Binding/BindCommandTests.cs
@@ -93,7 +93,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         {
             // Setup
             ProjectViewModel projectVM = CreateProjectViewModel();
-            BindCommand testSubject = this.PrepareCommpandForExecution(new ConnectionInformation(new Uri("http://127.0.0.0")));
+            BindCommand testSubject = this.PrepareCommandForExecution(new ConnectionInformation(new Uri("http://127.0.0.0")));
 
             // Case 1: All the requirements are set
             // Act + Verify
@@ -126,7 +126,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         {
             // Setup
             ProjectViewModel projectVM = CreateProjectViewModel();
-            BindCommand testSubject = this.PrepareCommpandForExecution(new ConnectionInformation(new Uri("http://127.0.0.0")));
+            BindCommand testSubject = this.PrepareCommandForExecution(new ConnectionInformation(new Uri("http://127.0.0.0")));
             ProjectMock project1 = this.solutionMock.Projects.Single();
 
             // Case 1: SolutionExistsAndNotBuildingAndNotDebugging is not active
@@ -151,7 +151,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         public void BindCommand_ExecuteBind()
         {
             // Setup
-            BindCommand testSubject = this.PrepareCommpandForExecution(new ConnectionInformation(new Uri("http://127.0.0.0")));
+            BindCommand testSubject = this.PrepareCommandForExecution(new ConnectionInformation(new Uri("http://127.0.0.0")));
 
             // Act
             var projectToBind1 = new ProjectInformation { Key = "1" };
@@ -175,7 +175,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         {
             // Setup
             ProjectViewModel projectVM = CreateProjectViewModel();
-            BindCommand testSubject = this.PrepareCommpandForExecution(new ConnectionInformation(new Uri("http://127.0.0.0")));
+            BindCommand testSubject = this.PrepareCommandForExecution(new ConnectionInformation(new Uri("http://127.0.0.0")));
             var progressEvents = new ConfigurableProgressEvents();
 
             foreach (var controllerResult in (ProgressControllerResult[])Enum.GetValues(typeof(ProgressControllerResult)))
@@ -221,7 +221,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             projects[0].IsBound = true;
             ProjectViewModel projectVM = projects[1];
 
-            BindCommand testSubject = this.PrepareCommpandForExecution(new ConnectionInformation(serverVM.Url));
+            BindCommand testSubject = this.PrepareCommandForExecution(new ConnectionInformation(serverVM.Url));
             var progressEvents = new ConfigurableProgressEvents();
             testSubject.Controller.State.ConnectedServers.Add(serverVM);
             testSubject.Controller.State.SetBoundProject(projects[0]);
@@ -258,7 +258,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             });
             var projects = serverVM.Projects.ToArray();
             ProjectViewModel projectVM = projects[0];
-            BindCommand testSubject = this.PrepareCommpandForExecution(new ConnectionInformation(serverVM.Url));
+            BindCommand testSubject = this.PrepareCommandForExecution(new ConnectionInformation(serverVM.Url));
             var progressEvents = new ConfigurableProgressEvents();
             testSubject.Controller.State.ConnectedServers.Add(serverVM);
 
@@ -294,7 +294,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             });
             ProjectViewModel projectVM = serverVM.Projects.ToArray()[0];
             ConfigurableUserNotification userNotifications = new ConfigurableUserNotification();
-            BindCommand testSubject = this.PrepareCommpandForExecution(new ConnectionInformation(serverVM.Url), userNotifications);
+            BindCommand testSubject = this.PrepareCommandForExecution(new ConnectionInformation(serverVM.Url), userNotifications);
             var progressEvents = new ConfigurableProgressEvents();
             testSubject.UserNotification.ShowNotificationError("Need to make sure that this is clear once started", NotificationIds.FailedToBindId, new RelayCommand(() => { }));
 
@@ -350,7 +350,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             return new ServerViewModel(new ConnectionInformation(new Uri("http://123")));
         }
 
-        private BindCommand PrepareCommpandForExecution(ConnectionInformation connection, ConfigurableUserNotification notifications = null)
+        private BindCommand PrepareCommandForExecution(ConnectionInformation connection, ConfigurableUserNotification notifications = null)
         {
             BindCommand testSubject = this.CreateBindCommand();
             testSubject.UserNotification = notifications;

--- a/src/Integration.UnitTests/Binding/BindCommandTests.cs
+++ b/src/Integration.UnitTests/Binding/BindCommandTests.cs
@@ -6,15 +6,16 @@
 //-----------------------------------------------------------------------
 
 using EnvDTE;
-using SonarLint.VisualStudio.Progress.Controller;
 using Microsoft.TeamFoundation.Client.CommandTarget;
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarLint.VisualStudio.Integration.Binding;
 using SonarLint.VisualStudio.Integration.Resources;
 using SonarLint.VisualStudio.Integration.Service;
+using SonarLint.VisualStudio.Integration.State;
 using SonarLint.VisualStudio.Integration.TeamExplorer;
 using SonarLint.VisualStudio.Integration.WPF;
+using SonarLint.VisualStudio.Progress.Controller;
 using System;
 using System.ComponentModel.Design;
 using System.Linq;
@@ -39,7 +40,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             this.sonarQubeService = new ConfigurableSonarQubeServiceWrapper();
             this.workflow = new TestBindingWorkflow();
             this.serviceProvider = new ConfigurableServiceProvider();
-            this.serviceProvider.RegisterService(typeof(DTE), this.dteMock = new DTEMock());
+            this.dteMock = new DTEMock();
+            this.serviceProvider.RegisterService(typeof(DTE), this.dteMock);
             this.solutionMock = new SolutionMock();
             this.monitorSelection = KnownUIContextsAccessor.MonitorSelectionService;
             this.projectSystemHelper = new ConfigurableVsProjectSystemHelper(this.serviceProvider);
@@ -71,16 +73,18 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         [TestMethod]
         public void BindCommand_Ctor_ArgumentChecks()
         {
+            BindCommand suppressAnalysisWarning;
+
             Exceptions.Expect<ArgumentNullException>(() =>
             {
-                new BindCommand(null, new ConfigurableSonarQubeServiceWrapper());
+                suppressAnalysisWarning = new BindCommand(null, new ConfigurableSonarQubeServiceWrapper());
             });
 
             ThreadHelper.SetCurrentThreadAsUIThread();
             var controller = new ConnectSectionController(new ServiceContainer(), new SonarQubeServiceWrapper(new ServiceContainer()), new ConfigurableActiveSolutionTracker());
             Exceptions.Expect<ArgumentNullException>(() =>
             {
-                new BindCommand(controller, null);
+                suppressAnalysisWarning = new BindCommand(controller, null);
             });
         }
 
@@ -90,7 +94,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             // Setup
             ProjectViewModel projectVM = CreateProjectViewModel();
             BindCommand testSubject = this.PrepareCommpandForExecution(new ConnectionInformation(new Uri("http://127.0.0.0")));
-            ProjectMock project1 = this.solutionMock.Projects.Single();
 
             // Case 1: All the requirements are set
             // Act + Verify
@@ -105,14 +108,14 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             // Act + Verify
             Assert.IsFalse(testSubject.WpfCommand.CanExecute(projectVM), "No connection");
 
-            // Case 4: Connecting
+            // Case 4: busy
             this.sonarQubeService.SetConnection(new Uri("http://127.0.0.0"));
-            testSubject.Controller.IsConnecting = true;
+            testSubject.Controller.State.IsBusy = true;
             // Act + Verify
             Assert.IsFalse(testSubject.WpfCommand.CanExecute(projectVM), "Connecting");
 
             // Case 5: No host
-            testSubject.Controller.IsConnecting = false;
+            testSubject.Controller.State.IsBusy = false;
             testSubject.ProgressControlHost = null;
             // Act + Verify
             Assert.IsFalse(testSubject.WpfCommand.CanExecute(projectVM), "No host");
@@ -151,7 +154,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             BindCommand testSubject = this.PrepareCommpandForExecution(new ConnectionInformation(new Uri("http://127.0.0.0")));
 
             // Act
-            var projectToBind1 = new ProjectInformation() { Key = "1" };
+            var projectToBind1 = new ProjectInformation { Key = "1" };
             ProjectViewModel projectVM1 = CreateProjectViewModel(projectToBind1);
             testSubject.WpfCommand.Execute(projectVM1);
 
@@ -159,8 +162,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             this.workflow.AssertBoundProject(projectVM1);
 
             // Act, bind a different project
-            var projectToBind2 = new ProjectInformation() { Key = "2" };
-            ProjectViewModel projectVM2 = CreateProjectViewModel(projectToBind1);
+            var projectToBind2 = new ProjectInformation { Key = "2" };
+            ProjectViewModel projectVM2 = CreateProjectViewModel(projectToBind2);
             testSubject.WpfCommand.Execute(projectVM2);
 
             // Verify
@@ -211,8 +214,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             ServerViewModel serverVM = CreateServerViewModel();
             serverVM.SetProjects(new[]
             {
-                new ProjectInformation() { Key = "key1" },
-                new ProjectInformation() { Key = "key2" },
+                new ProjectInformation { Key = "key1" },
+                new ProjectInformation { Key = "key2" },
             });
             var projects = serverVM.Projects.ToArray();
             projects[0].IsBound = true;
@@ -220,10 +223,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
 
             BindCommand testSubject = this.PrepareCommpandForExecution(new ConnectionInformation(serverVM.Url));
             var progressEvents = new ConfigurableProgressEvents();
-            testSubject.Controller.ConnectedServers.Add(serverVM);
-            testSubject.Controller.BoundProjects.Add(projects[0]);
+            testSubject.Controller.State.ConnectedServers.Add(serverVM);
+            testSubject.Controller.State.SetBoundProject(projects[0]);
 
             // Sanity
+            Assert.IsTrue(testSubject.Controller.State.HasBoundProject);
             Assert.IsTrue(testSubject.WpfCommand.CanExecute(projectVM));
 
             // Act - start
@@ -232,7 +236,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             // Verify 
             Assert.IsTrue(projects[0].IsBound, "Expected to remain bound at this point");
             Assert.IsFalse(projects[1].IsBound, "Expected to remain unbound at this point");
-            Assert.AreSame(projects[0], testSubject.Controller.BoundProjects.Single(), "Expected to be the only bound project");
+            Assert.IsTrue(testSubject.Controller.State.HasBoundProject);
 
             // Act - finish
             progressEvents.SimulateFinished(ProgressControllerResult.Succeeded);
@@ -240,7 +244,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             // Verify 
             Assert.IsFalse(projects[0].IsBound, "Expected to become unbound at this point");
             Assert.IsTrue(projects[1].IsBound, "Expected to become bound at this point");
-            Assert.AreSame(projects[1], testSubject.Controller.BoundProjects.Single(), "Expected to be the only bound project");
+            Assert.IsTrue(testSubject.Controller.State.HasBoundProject);
         }
 
         [TestMethod]
@@ -250,15 +254,15 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             ServerViewModel serverVM = CreateServerViewModel();
             serverVM.SetProjects(new[]
             {
-                new ProjectInformation() { Key = "key1" }
+                new ProjectInformation { Key = "key1" }
             });
             var projects = serverVM.Projects.ToArray();
             ProjectViewModel projectVM = projects[0];
             BindCommand testSubject = this.PrepareCommpandForExecution(new ConnectionInformation(serverVM.Url));
             var progressEvents = new ConfigurableProgressEvents();
-            testSubject.Controller.ConnectedServers.Add(serverVM);
+            testSubject.Controller.State.ConnectedServers.Add(serverVM);
 
-            foreach (ProgressControllerResult result in Enum.GetValues(typeof(ProgressControllerResult)))
+            foreach (ProgressControllerResult result in Enum.GetValues(typeof(ProgressControllerResult)).OfType<ProgressControllerResult>())
             {
                 // Setup
                 testSubject.SetBindingInProgress(progressEvents, projectVM);
@@ -286,15 +290,15 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             ServerViewModel serverVM = CreateServerViewModel();
             serverVM.SetProjects(new[]
             {
-                new ProjectInformation() { Key = "key1" }
+                new ProjectInformation { Key = "key1" }
             });
             ProjectViewModel projectVM = serverVM.Projects.ToArray()[0];
-            BindCommand testSubject = this.PrepareCommpandForExecution(new ConnectionInformation(serverVM.Url));
-            ConfigurableUserNotification userNotifications = (ConfigurableUserNotification)testSubject.UserNotification;
+            ConfigurableUserNotification userNotifications = new ConfigurableUserNotification();
+            BindCommand testSubject = this.PrepareCommpandForExecution(new ConnectionInformation(serverVM.Url), userNotifications);
             var progressEvents = new ConfigurableProgressEvents();
             testSubject.UserNotification.ShowNotificationError("Need to make sure that this is clear once started", NotificationIds.FailedToBindId, new RelayCommand(() => { }));
 
-            foreach (ProgressControllerResult result in Enum.GetValues(typeof(ProgressControllerResult)))
+            foreach (ProgressControllerResult result in Enum.GetValues(typeof(ProgressControllerResult)).OfType<ProgressControllerResult>())
             {
                 // Act - start
                 testSubject.SetBindingInProgress(progressEvents, projectVM);
@@ -346,10 +350,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             return new ServerViewModel(new ConnectionInformation(new Uri("http://123")));
         }
 
-        private BindCommand PrepareCommpandForExecution(ConnectionInformation connection)
+        private BindCommand PrepareCommpandForExecution(ConnectionInformation connection, ConfigurableUserNotification notifications = null)
         {
             BindCommand testSubject = this.CreateBindCommand();
-            testSubject.UserNotification = new ConfigurableUserNotification();
+            testSubject.UserNotification = notifications;
             this.sonarQubeService.SetConnection(connection);
             testSubject.ProgressControlHost = new ConfigurableProgressControlHost();
             this.monitorSelection.SetContext(VSConstants.UICONTEXT.SolutionExistsAndNotBuildingAndNotDebugging_guid, true);
@@ -380,7 +384,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         }
         private BindCommand CreateBindCommand()
         {
-            var controller = new ConnectSectionController(this.serviceProvider, this.sonarQubeService, new ConfigurableActiveSolutionTracker(), Dispatcher.CurrentDispatcher);
+            var controller = new ConnectSectionController(this.serviceProvider, new TransferableVisualState(), this.sonarQubeService, new ConfigurableActiveSolutionTracker(), Dispatcher.CurrentDispatcher);
             return new BindCommand(controller, this.sonarQubeService, this.workflow, this.projectSystemHelper);
         }
 

--- a/src/Integration.UnitTests/Connection/ConnectionWorkflowTests.cs
+++ b/src/Integration.UnitTests/Connection/ConnectionWorkflowTests.cs
@@ -10,6 +10,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarLint.VisualStudio.Integration.Connection;
 using SonarLint.VisualStudio.Integration.Resources;
 using SonarLint.VisualStudio.Integration.Service;
+using SonarLint.VisualStudio.Integration.State;
 using SonarLint.VisualStudio.Integration.TeamExplorer;
 using SonarLint.VisualStudio.Integration.WPF;
 using System;
@@ -109,7 +110,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
         public void ConnectionWorkflow_DontWarnAgainCanExec_NoSettings_IsFalse()
         {
             // Setup
-            var controller = new ConnectSectionController(new ConfigurableServiceProvider(false), this.sonarQubeService, new ConfigurableActiveSolutionTracker(), Dispatcher.CurrentDispatcher);
+            var controller = new ConnectSectionController(new ConfigurableServiceProvider(false), new TransferableVisualState(), sonarQubeService, new ConfigurableActiveSolutionTracker(), Dispatcher.CurrentDispatcher);
             var command = new ConnectCommand(controller, this.sonarQubeService);
             ConnectedProjectsCallback callback = (c, p) => { };
             var testSubject = new ConnectionWorkflow(command, callback);
@@ -123,7 +124,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
         {
             // Setup
             var connectionInfo = new ConnectionInformation(new Uri("http://server"));
-            var projects = new ProjectInformation[] { new ProjectInformation() { Key = "project1" } };
+            var projects = new ProjectInformation[] { new ProjectInformation { Key = "project1" } };
             this.sonarQubeService.ReturnProjectInformation = projects;
             ConnectCommand command;
             bool projectChangedCallbackCalled = false;
@@ -158,7 +159,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
         {
             // Setup
             var connectionInfo = new ConnectionInformation(new Uri("http://server"));
-            var projects = new ProjectInformation[] { new ProjectInformation() { Key = "project1" } };
             ConnectCommand command;
             bool projectChangedCallbackCalled = false;
             ConnectedProjectsCallback projectsChanged = (c, p) =>
@@ -181,7 +181,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
             // Verify
             executionEvents.AssertProgressMessages(connectionMessage, Strings.ConnectionResultFailure);
             Assert.IsTrue(projectChangedCallbackCalled, "ConnectedProjectsCallaback was not called");
-            sonarQubeService.AssertConnectRequests(1);
+            this.sonarQubeService.AssertConnectRequests(1);
             Assert.IsNull(((ISonarQubeServiceWrapper)this.sonarQubeService).CurrentConnection, "Unexpected connection");
             notifications.AssertNotification(NotificationIds.FailedToConnectId, Strings.ConnectionFailed);
 
@@ -193,7 +193,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
             // Verify
             executionEvents.AssertProgressMessages(connectionMessage, Strings.ConnectionResultFailure);
             Assert.IsTrue(projectChangedCallbackCalled, "ConnectedProjectsCallaback was not called");
-            sonarQubeService.AssertConnectRequests(2);
+            this.sonarQubeService.AssertConnectRequests(2);
             Assert.IsNull(((ISonarQubeServiceWrapper)this.sonarQubeService).CurrentConnection, "Unexpected connection");
             notifications.AssertNotification(NotificationIds.FailedToConnectId, Strings.ConnectionFailed);
 
@@ -210,7 +210,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
             // Verify
             executionEvents.AssertProgressMessages(connectionMessage, Strings.ConnectionResultCancellation);
             Assert.IsTrue(projectChangedCallbackCalled, "ConnectedProjectsCallaback was not called");
-            sonarQubeService.AssertConnectRequests(3);
+            this.sonarQubeService.AssertConnectRequests(3);
             Assert.IsNull(((ISonarQubeServiceWrapper)this.sonarQubeService).CurrentConnection, "Unexpected connection");
             notifications.AssertNotification(NotificationIds.FailedToConnectId, Strings.ConnectionFailed);
         }
@@ -219,7 +219,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
         #region Helpers
         private ConnectionWorkflow CreateTestSubject(ConnectedProjectsCallback projectsChanged, out ConnectCommand owningCommand)
         {
-            var controller = new ConnectSectionController(this.serviceProvider, this.sonarQubeService, new ConfigurableActiveSolutionTracker(), Dispatcher.CurrentDispatcher);
+            var controller = new ConnectSectionController(this.serviceProvider, new TransferableVisualState(), this.sonarQubeService, new ConfigurableActiveSolutionTracker(), Dispatcher.CurrentDispatcher);
             owningCommand = controller.ConnectCommand;
             return new ConnectionWorkflow(owningCommand, projectsChanged);
         }

--- a/src/Integration.UnitTests/Integration.UnitTests.csproj
+++ b/src/Integration.UnitTests/Integration.UnitTests.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Binding\ProjectRuleSetWriterTests.cs" />
     <Compile Include="ActiveSolutionTrackerTests.cs" />
     <Compile Include="Service\VersionHelperTests.cs" />
+    <Compile Include="State\TransferableVisualStateTests.cs" />
     <Compile Include="TeamExplorer\ConnectSectionControllerTests.cs" />
     <Compile Include="TeamExplorer\ConnectSectionTests.cs" />
     <Compile Include="TeamExplorer\ConnectSectionViewModelTests.cs" />

--- a/src/Integration.UnitTests/State/TransferableVisualStateTests.cs
+++ b/src/Integration.UnitTests/State/TransferableVisualStateTests.cs
@@ -1,0 +1,73 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TransferableVisualStateTests.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarLint.VisualStudio.Integration.State;
+using SonarLint.VisualStudio.Integration.TeamExplorer;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests.State
+{
+    [TestClass]
+    public class TransferableVisualStateTests
+    {
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            ThreadHelper.SetCurrentThreadAsUIThread();
+        }
+
+        [TestMethod]
+        public void TransferableVisualState_DefaultState()
+        {
+            // Setup
+            var testSubject = new TransferableVisualState();
+
+            // Verify
+            Assert.IsFalse(testSubject.HasBoundProject);
+            Assert.IsFalse(testSubject.IsBusy);
+            Assert.IsNotNull(testSubject.ConnectedServers);
+            Assert.AreEqual(0, testSubject.ConnectedServers.Count);
+        }
+
+        [TestMethod]
+        public void TransferableVisualState_BoundProjectManagement()
+        {
+            // Setup
+            var testSubject = new TransferableVisualState();
+            var server = new ServerViewModel(new Integration.Service.ConnectionInformation(new System.Uri("http://server")));
+            var project1 = new ProjectViewModel(server, new Integration.Service.ProjectInformation());
+            var project2 = new ProjectViewModel(server, new Integration.Service.ProjectInformation());
+
+            // Act (bind to something)
+            testSubject.SetBoundProject(project1);
+
+            // Verify
+            Assert.IsTrue(testSubject.HasBoundProject);
+            Assert.IsTrue(project1.IsBound);
+            Assert.IsFalse(project2.IsBound);
+            Assert.IsFalse(server.ShowAllProjects);
+
+            // Act (bind to something else)
+            testSubject.SetBoundProject(project2);
+
+            // Verify
+            Assert.IsTrue(testSubject.HasBoundProject);
+            Assert.IsFalse(project1.IsBound);
+            Assert.IsTrue(project2.IsBound);
+            Assert.IsFalse(server.ShowAllProjects);
+
+            // Act(clear binding)
+            testSubject.ClearBoundProject();
+
+            // Verify
+            Assert.IsFalse(testSubject.HasBoundProject);
+            Assert.IsFalse(project1.IsBound);
+            Assert.IsFalse(project2.IsBound);
+            Assert.IsTrue(server.ShowAllProjects);
+        }
+    }
+}

--- a/src/Integration.UnitTests/TeamExplorer/ConnectSectionControllerTests.cs
+++ b/src/Integration.UnitTests/TeamExplorer/ConnectSectionControllerTests.cs
@@ -332,7 +332,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             testSubject.NotificationAccessor.ShowNotificationError("message", NotificationIds.FailedToFindBoundProjectKeyId, null);
             testSubject.State.ConnectedServers.Add(new ServerViewModel(new ConnectionInformation(new Uri("http://zzz1"))));
             testSubject.State.ConnectedServers.Add(new ServerViewModel(new ConnectionInformation(new Uri("http://zzz2"))));
-            testSubject.State.ConnectedServers.ToList().ForEach(s => s.Projects.Add(new ProjectViewModel(s, new ProjectInformation()) { IsBound = true }));
+            testSubject.State.ConnectedServers.ToList().ForEach(s => s.Projects.Add(new ProjectViewModel(s, new ProjectInformation())));
             var allProjects = testSubject.State.ConnectedServers.SelectMany(s => s.Projects).ToList();
             testSubject.State.SetBoundProject(allProjects.First());
 

--- a/src/Integration.UnitTests/TeamExplorer/ConnectSectionTests.cs
+++ b/src/Integration.UnitTests/TeamExplorer/ConnectSectionTests.cs
@@ -50,7 +50,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             Assert.IsNotNull(testSubject.View, "Failed to get the View");
             Assert.IsNotNull(testSubject.ViewModel, "Failed to get the ViewModel");
 
-            // Case 2: re-initialization with connection but no projects;
+            // Case 2: re-initialization with connection but no projects
             var connection = new ConnectionInformation(new Uri("http://localhost"));
             this.sonarQubeService.SetConnection(connection);
             this.sonarQubeService.ReturnProjectInformation = new ProjectInformation[0];
@@ -65,7 +65,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             ConnectSectionViewModel vm = ((IConnectSection)testSubject).ViewModel;
             VerifyConnectSectionViewModelIsConnectedAndHasNoProjects(vm, connection);
 
-            // Case 3: re-initialization with connection and projects;
+            // Case 3: re-initialization with connection and projects
             var projects = new [] { new ProjectInformation() };
             this.sonarQubeService.ReturnProjectInformation = projects;
             ResetSection(testSubject);
@@ -160,7 +160,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
         private static void ResetSection(ConnectSection section)
         {
             section.Controller.Detach(section);
-            section.Controller.ConnectedServers.Clear();
+            section.Controller.State.ConnectedServers.Clear();
             section.Initialize(null, new Microsoft.TeamFoundation.Controls.SectionInitializeEventArgs(new ServiceContainer(), null));
             section.Refresh();
         }
@@ -175,13 +175,13 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
 
         private static void VerifyConnectSectionViewModelIsNotConnected(ConnectSectionViewModel vm, ConnectionInformation connection)
         {
-            ServerViewModel serverVM = vm.ConnectedServers.SingleOrDefault(s => s.Url == connection.ServerUri);
+            ServerViewModel serverVM = vm.State.ConnectedServers.SingleOrDefault(s => s.Url == connection.ServerUri);
             Assert.IsNull(serverVM, "Should not find server view model for {0}", connection.ServerUri);
         }
 
         private static ServerViewModel VerifyConnectSectionViewModelIsConnected(ConnectSectionViewModel vm, ConnectionInformation connection)
         {
-            ServerViewModel serverVM = vm.ConnectedServers.SingleOrDefault(s => s.Url == connection.ServerUri);
+            ServerViewModel serverVM = vm.State.ConnectedServers.SingleOrDefault(s => s.Url == connection.ServerUri);
             Assert.IsNotNull(serverVM, "Could not find server view model for {0}", connection.ServerUri);
 
             return serverVM;
@@ -197,7 +197,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
 
         private class TestCommandTarget : IOleCommandTarget
         {
-            private int queryStatusNumberOfCalls = 0;
+            private int queryStatusNumberOfCalls;
 
             #region IOleCommandTarget
             int IOleCommandTarget.Exec(ref Guid pguidCmdGroup, uint nCmdID, uint nCmdexecopt, IntPtr pvaIn, IntPtr pvaOut)

--- a/src/Integration.UnitTests/TeamExplorer/TestableConnectSectionController.cs
+++ b/src/Integration.UnitTests/TeamExplorer/TestableConnectSectionController.cs
@@ -7,6 +7,7 @@
 
 using SonarLint.VisualStudio.Integration.Connection;
 using SonarLint.VisualStudio.Integration.Service;
+using SonarLint.VisualStudio.Integration.State;
 using SonarLint.VisualStudio.Integration.TeamExplorer;
 using System;
 using System.Windows.Threading;
@@ -17,14 +18,15 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
     {
         public TestableConnectSectionController(IServiceProvider serviceProvider,
                                                ISonarQubeServiceWrapper sonarQubeService)
-            : this(serviceProvider, sonarQubeService, new ConfigurableActiveSolutionTracker())
+            : this(serviceProvider, new TransferableVisualState(), sonarQubeService, new ConfigurableActiveSolutionTracker())
         {
         }
 
         public TestableConnectSectionController(IServiceProvider serviceProvider,
+                                                TransferableVisualState state,
                                                 ISonarQubeServiceWrapper sonarQubeService,
                                                 IActiveSolutionTracker tracker)
-            : base(serviceProvider, sonarQubeService, tracker, Dispatcher.CurrentDispatcher)
+            : base(serviceProvider, state, sonarQubeService, tracker, Dispatcher.CurrentDispatcher)
         {
         }
 
@@ -36,7 +38,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
         } = new ConfigurableUserNotification();
 
         #region Overrides
-        internal override IUserNotification Notification
+        protected override IUserNotification Notification
         {
             get
             {
@@ -44,7 +46,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             }
         }
 
-        internal protected override void SetProjects(object sender, ConnectedProjectsEventArgs args)
+        protected override void SetProjects(object sender, ConnectedProjectsEventArgs args)
         {
             if (this.SetProjectsAction != null)
             {
@@ -57,6 +59,21 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
 
             // This call will make sure that that async request is executed now 
             DispatcherHelper.DispatchFrame();
+        }
+        #endregion
+
+        #region Test accessors
+        public void InvokeSetProjects(ConnectedProjectsEventArgs args)
+        {
+            this.SetProjects(null, args);
+        }
+
+        public IUserNotification NotificationAccessor
+        {
+            get
+            {
+                return this.Notification;
+            }
         }
         #endregion
     }

--- a/src/Integration/Connection/ConnectCommand.cs
+++ b/src/Integration/Connection/ConnectCommand.cs
@@ -73,13 +73,13 @@ namespace SonarLint.VisualStudio.Integration.Connection
         {
             get
             {
-                return this.controller.IsConnecting;
+                return this.controller.State.IsBusy;
             }
             set
             {
-                if (this.controller.IsConnecting != value)
+                if (this.controller.State.IsBusy != value)
                 {
-                    this.controller.IsConnecting = value;
+                    this.controller.State.IsBusy = value;
                     this.WpfCommand.RequeryCanExecute();
                 }
             }
@@ -92,13 +92,13 @@ namespace SonarLint.VisualStudio.Integration.Connection
         {
             return this.SonarQubeService.CurrentConnection == null
                 && this.ProgressControlHost != null
-                && !this.controller.IsConnecting;
+                && !this.controller.State.IsBusy;
         }
 
         private void OnConnect()
         {
             Debug.Assert(this.OnConnectStatus());
-            Debug.Assert(!this.controller.IsConnecting, "Service is in a connecting state");
+            Debug.Assert(!this.controller.State.IsBusy, "Service is in a connecting state");
 
             var connectionInfo = this.connectionProvider.GetConnectionInformation(this.LastAttemptedConnection);
             if (connectionInfo != null)

--- a/src/Integration/Integration.csproj
+++ b/src/Integration/Integration.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Service\RoslynExporter\NuGetPackageInfo.cs" />
     <Compile Include="Service\RoslynExporter\RoslynExportProfile.cs" />
     <Compile Include="Service\VersionHelper.cs" />
+    <Compile Include="State\TransferableVisualState.cs" />
     <Compile Include="TeamExplorer\ITeamExplorerController.cs" />
     <Compile Include="TeamExplorer\ResourceHelper.cs" />
     <Compile Include="TeamExplorer\SonarQubeNavigationItem.cs" />

--- a/src/Integration/State/TransferableVisualState.cs
+++ b/src/Integration/State/TransferableVisualState.cs
@@ -1,0 +1,83 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="TransferableVisualState.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Microsoft.VisualStudio.Shell;
+using SonarLint.VisualStudio.Integration.TeamExplorer;
+using SonarLint.VisualStudio.Integration.WPF;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+
+namespace SonarLint.VisualStudio.Integration.State
+{
+    internal class TransferableVisualState : ViewModelBase
+    {
+        private readonly ObservableCollection<ServerViewModel> connectedServers = new ObservableCollection<ServerViewModel>();
+        private ProjectViewModel boundProject;
+        private bool isBusy;
+
+        public ObservableCollection<ServerViewModel> ConnectedServers
+        {
+            get
+            {
+                Debug.Assert(ThreadHelper.CheckAccess(), $"{nameof(ConnectedServers)} should only be accessed from the UI thread");
+                return this.connectedServers;
+            }
+        }
+
+        public bool HasBoundProject
+        {
+            get
+            {
+                Debug.Assert(ThreadHelper.CheckAccess(), $"{nameof(HasBoundProject)} should only be accessed from the UI thread");
+                return this.boundProject != null;
+            }
+        }
+
+        public bool IsBusy
+        {
+            get
+            {
+                Debug.Assert(ThreadHelper.CheckAccess(), $"{nameof(IsBusy)} should only be accessed from the UI thread");
+                return this.isBusy;
+            }
+            set
+            {
+                Debug.Assert(ThreadHelper.CheckAccess(), $"{nameof(IsBusy)} should only be set from the UI thread");
+                this.SetAndRaisePropertyChanged(ref this.isBusy, value);
+            }
+        }
+
+        public void SetBoundProject(ProjectViewModel project)
+        {
+            Debug.Assert(ThreadHelper.CheckAccess(), $"{nameof(SetBoundProject)} should only be accessed from the UI thread");
+            this.ClearBoundProject();
+
+            this.boundProject = project;
+            this.boundProject.IsBound = true;
+            this.boundProject.Owner.ShowAllProjects = false;
+
+#pragma warning disable S3236 // Methods with caller info attributes should not be invoked with explicit arguments, Justification: false positive (will use the calling method name internally)
+            this.RaisePropertyChanged(nameof(HasBoundProject));
+#pragma warning restore S3236 // Methods with caller info attributes should not be invoked with explicit arguments
+        }
+
+        public void ClearBoundProject()
+        {
+            Debug.Assert(ThreadHelper.CheckAccess(), $"{nameof(ClearBoundProject)} should only be accessed from the UI thread");
+            if (this.boundProject != null)
+            {
+                this.boundProject.IsBound = false;
+                this.boundProject.Owner.ShowAllProjects = true;
+                this.boundProject = null;
+
+#pragma warning disable S3236 // Methods with caller info attributes should not be invoked with explicit arguments, Justification: false positive (will use the calling method name internally)
+                this.RaisePropertyChanged(nameof(HasBoundProject));
+#pragma warning restore S3236 // Methods with caller info attributes should not be invoked with explicit arguments
+            }
+        }
+    }
+}

--- a/src/Integration/TeamExplorer/ConnectSectionController.cs
+++ b/src/Integration/TeamExplorer/ConnectSectionController.cs
@@ -42,7 +42,7 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
 
         [ImportingConstructor]
         public ConnectSectionController([Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider, SonarQubeServiceWrapper sonarQubeService, IActiveSolutionTracker solutionTacker)
-            : this(serviceProvider, null, sonarQubeService, solutionTacker, Dispatcher.CurrentDispatcher)
+            : this(serviceProvider, new TransferableVisualState(), sonarQubeService, solutionTacker, Dispatcher.CurrentDispatcher)
         {
             Debug.Assert(ThreadHelper.CheckAccess(), "Expected to be created on the UI thread");
         }
@@ -53,8 +53,13 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
                                     IActiveSolutionTracker solutionTacker,
                                     Dispatcher uiDispatcher)
         {
+           if (state == null)
+            {
+                throw new ArgumentNullException(nameof(state));
+            }
+
             this.serviceProvider = serviceProvider;
-            this.State = state ?? new TransferableVisualState();
+            this.State = state;
             this.State.PropertyChanged += this.OnStatePropertyChanged;
             this.uiDispatcher = uiDispatcher;
             this.sonarQubeService = sonarQubeService;

--- a/src/Integration/TeamExplorer/ConnectSectionController.cs
+++ b/src/Integration/TeamExplorer/ConnectSectionController.cs
@@ -14,10 +14,10 @@ using SonarLint.VisualStudio.Integration.Persistence;
 using SonarLint.VisualStudio.Integration.Progress;
 using SonarLint.VisualStudio.Integration.Resources;
 using SonarLint.VisualStudio.Integration.Service;
+using SonarLint.VisualStudio.Integration.State;
 using SonarLint.VisualStudio.Integration.WPF;
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.Globalization;
@@ -31,33 +31,31 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
     [PartCreationPolicy(CreationPolicy.Shared)]
     internal class ConnectSectionController : IServiceProvider, IDisposable
     {
-        private readonly ObservableCollection<ServerViewModel> connectedServers = new ObservableCollection<ServerViewModel>();
-        private readonly ObservableCollection<ProjectViewModel> boundProjects = new ObservableCollection<ProjectViewModel>();
         private readonly ISonarQubeServiceWrapper sonarQubeService;
         private readonly Dispatcher uiDispatcher;
         private readonly IServiceProvider serviceProvider;
         private readonly IActiveSolutionTracker solutionTacker;
 
-        private IConnectSection section;
-        private bool isDisposed = false;
-        private bool isConnecting = false;
-        private bool isBinding = false;
+        private bool isDisposed;
         private bool resetBindingWhenAttaching = true;
         private string boundSonarQubeProjectKey;
 
         [ImportingConstructor]
         public ConnectSectionController([Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider, SonarQubeServiceWrapper sonarQubeService, IActiveSolutionTracker solutionTacker)
-            : this(serviceProvider, sonarQubeService, solutionTacker, Dispatcher.CurrentDispatcher)
+            : this(serviceProvider, null, sonarQubeService, solutionTacker, Dispatcher.CurrentDispatcher)
         {
             Debug.Assert(ThreadHelper.CheckAccess(), "Expected to be created on the UI thread");
         }
 
         internal /*for test purposes*/ ConnectSectionController(IServiceProvider serviceProvider,
+                                    TransferableVisualState state,
                                     ISonarQubeServiceWrapper sonarQubeService,
                                     IActiveSolutionTracker solutionTacker,
                                     Dispatcher uiDispatcher)
         {
             this.serviceProvider = serviceProvider;
+            this.State = state ?? new TransferableVisualState();
+            this.State.PropertyChanged += this.OnStatePropertyChanged;
             this.uiDispatcher = uiDispatcher;
             this.sonarQubeService = sonarQubeService;
             this.solutionTacker = solutionTacker;
@@ -70,16 +68,39 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
             this.ToggleShowAllProjectsCommand = new RelayCommand<ServerViewModel>(this.ToggleShowAllProjects, this.CanToggleShowAllProjects);
         }
 
+        #region State
+        internal TransferableVisualState State
+        {
+            get;
+        }
+
+        private void OnStatePropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(this.State.IsBusy))
+            {
+                ConnectSectionViewModel vm = this.AttachedSection?.ViewModel;
+                if (vm != null)
+                {
+                    vm.IsBusy = this.State.IsBusy;
+                }
+            }
+        }
+        #endregion
+
+        #region Notifications
+#pragma warning disable S2333 // Redundant modifiers should be removed, Justification: for test purposes
         /// <summary>
         /// API to notify the user. Can be null when we're not supposed to notify the user.
         /// </summary>
-        internal /*for testing purposes*/ virtual IUserNotification Notification
+        protected virtual IUserNotification Notification
+#pragma warning restore S2333 // Redundant modifiers should be removed
         {
             get
             {
                 return this.AttachedSection?.ViewModel;
             }
         }
+        #endregion
 
         #region Initialization
         internal /*for testing purposes*/ void SetConnectCommand(ConnectCommand cmd = null)
@@ -101,85 +122,24 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
 
         #region Controller API
 
-        public bool IsConnecting
-        {
-            get { return this.isConnecting; }
-            set
-            {
-                this.isConnecting = value;
-                this.UpdateBusyState();
-            }
-        }
-
-        public bool IsBinding
-        {
-            get { return this.isBinding; }
-            set
-            {
-                this.isBinding = value;
-                this.UpdateBusyState();
-            }
-        }
-
-        internal ObservableCollection<ServerViewModel> ConnectedServers
-        {
-            get
-            {
-                Debug.Assert(ThreadHelper.CheckAccess(), $"{nameof(ConnectedServers)} should only be accessed from the UI thread");
-                return this.connectedServers;
-            }
-        }
-
-        public ObservableCollection<ProjectViewModel> BoundProjects
-        {
-            // We only need the bound projects for easy tracking of whether any of the 
-            // servers has a bound project (see ConnectSectionView.xaml), so need to keep 
-            // it up-to-date by using ClearBoundProjects and SetBoundProject
-            get
-            {
-                Debug.Assert(ThreadHelper.CheckAccess(), $"{nameof(BoundProjects)} should only be accessed from the UI thread");
-                return this.boundProjects;
-            }
-        }
-
         internal IConnectSection AttachedSection
         {
-            get { return this.section; }
+            get;
+            private set;
         }
 
-        public void ClearAllBoundProjects()
+        public void ClearBoundProject()
         {
-            Debug.Assert(ThreadHelper.CheckAccess(), $"{nameof(ClearAllBoundProjects)} should only be accessed from the UI thread");
+            Debug.Assert(ThreadHelper.CheckAccess(), $"{nameof(ClearBoundProject)} should only be accessed from the UI thread");
             this.ClearBindingErrorNotifications();
-            foreach (ServerViewModel server in this.ConnectedServers)
-            {
-                this.ClearBoundProjects(server);
-            }
-        }
-
-        public void ClearBoundProjects(ServerViewModel serverViewModel)
-        {
-            Debug.Assert(ThreadHelper.CheckAccess(), $"{nameof(ClearBoundProjects)} should only be accessed from the UI thread");
-            this.ClearBindingErrorNotifications();
-            foreach (ProjectViewModel project in serverViewModel.Projects)
-            {
-                if (this.BoundProjects.Contains(project))
-                {
-                    this.BoundProjects.Remove(project);
-                }
-                project.IsBound = false;
-            }
-
-            serverViewModel.ShowAllProjects = true;
+            this.State.ClearBoundProject();
         }
 
         public void SetBoundProject(ProjectViewModel projectViewModel)
         {
             Debug.Assert(ThreadHelper.CheckAccess(), $"{nameof(SetBoundProject)} should only be accessed from the UI thread");
             this.ClearBindingErrorNotifications();
-            projectViewModel.IsBound = true;
-            projectViewModel.Owner.ShowAllProjects = false;
-            this.BoundProjects.Add(projectViewModel);
+            this.State.SetBoundProject(projectViewModel);
         }
 
         public void Attach(IConnectSection section)
@@ -189,9 +149,9 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
                 throw new ArgumentNullException(nameof(section));
             }
 
-            Debug.Assert(this.section == null, "Already attached. Detach first");
+            Debug.Assert(this.AttachedSection == null, "Already attached. Detach first");
 
-            this.section = section;
+            this.AttachedSection = section;
             this.AttachViewModel(section.ViewModel);
             this.AttachView((IProgressControlHost)section.View);
 
@@ -216,29 +176,27 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
                 throw new ArgumentNullException(nameof(section));
             }
 
-            if (this.section == null) // Can be called multiple times
+            if (this.AttachedSection == null) // Can be called multiple times
             {
                 return;
             }
 
             this.SaveState();
-            this.section.ViewModel.ConnectedServers = null;
-            this.section.ViewModel.BoundProjects = null;
-            this.DetachView((IProgressControlHost)section.View);
-            this.DetachViewModel(section.ViewModel);
-            this.section = null;
+            this.AttachedSection.ViewModel.State = null;
+            this.DetachView();
+            this.DetachViewModel();
+            this.AttachedSection = null;
         }
 
         private void LoadState()
         {
-            Debug.Assert(this.section != null, "Not attached to any section attached");
+            Debug.Assert(this.AttachedSection != null, "Not attached to any section attached");
 
-            if (this.section != null)
+            if (this.AttachedSection != null)
             {
-                this.section.ViewModel.ConnectedServers = this.ConnectedServers;
-                this.section.ViewModel.BoundProjects = this.BoundProjects;
+                this.AttachedSection.ViewModel.State = this.State;
 
-                IProgressControlHost progressHost = section.View as IProgressControlHost;
+                IProgressControlHost progressHost = this.AttachedSection.View as IProgressControlHost;
                 Debug.Assert(progressHost != null, "View is expected to implement IProgressControlHost");
                 ProgressStepRunner.ChangeHost(progressHost);
             }
@@ -246,22 +204,12 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
 
         private void SaveState()
         {
-            Debug.Assert(this.section != null, "Not attached to any section attached");
+            Debug.Assert(this.AttachedSection != null, "Not attached to any section attached");
             // All the state (ConnectedServers) is currently on the controller
             // or defined elsewhere, so just verifying that at this point
-            if (this.section != null)
+            if (this.AttachedSection != null)
             {
-                Debug.Assert(ReferenceEquals(this.ConnectedServers, this.section.ViewModel.ConnectedServers), "Broken invariant - the connected servers are different!");
-            }
-        }
-
-        private void UpdateBusyState()
-        {
-            Debug.Assert(ThreadHelper.CheckAccess(), "Expected to be called on the UI thread");
-            ConnectSectionViewModel vm = this.section?.ViewModel;
-            if (vm != null)
-            {
-                vm.IsBusy = this.IsBinding || this.IsConnecting;
+                Debug.Assert(ReferenceEquals(this.State, this.AttachedSection.ViewModel.State), "Broken invariant - the connected servers are different!");
             }
         }
 
@@ -297,8 +245,7 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
 
         private bool CanExecRefresh()
         {
-            return !this.IsConnecting
-                && !this.IsBinding
+            return !this.State.IsBusy
                 && this.sonarQubeService.CurrentConnection != null;
         }
 
@@ -419,7 +366,9 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
         #endregion
 
         #region Workflow event handler
-        internal /*for testing purposes*/ protected virtual void SetProjects(object sender, ConnectedProjectsEventArgs args)
+#pragma warning disable S2333 // Redundant modifiers should be removed, Justification: for test purposes
+        protected virtual void SetProjects(object sender, ConnectedProjectsEventArgs args)
+#pragma warning restore S2333 // Redundant modifiers should be removed
         {
             if (this.uiDispatcher.CheckAccess())
             {
@@ -445,20 +394,19 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
             if (projects == null)
             {
                 // Disconnected, clear all
-                this.ConnectedServers.ToList().ForEach(s => this.ClearBoundProjects(s));
-                this.ConnectedServers.Clear();
-                Debug.Assert(this.BoundProjects.Count == 0, "Not expected any bound projects");
+                this.ClearBoundProject();
+                this.State.ConnectedServers.Clear();
             }
             else
             {
-                var existingServerVM = this.ConnectedServers.Where(serverVM => serverVM.Url == connection.ServerUri).SingleOrDefault();
+                var existingServerVM = this.State.ConnectedServers.SingleOrDefault(serverVM => serverVM.Url == connection.ServerUri);
                 ServerViewModel serverViewModel;
                 if (existingServerVM == null)
                 {
                     // Add new server
                     serverViewModel = new ServerViewModel(connection);
                     this.AddServerVMCommands(serverViewModel);
-                    this.ConnectedServers.Add(serverViewModel);
+                    this.State.ConnectedServers.Add(serverViewModel);
                 }
                 else
                 {
@@ -467,7 +415,7 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
                 }
 
                 serverViewModel.SetProjects(projects);
-                Debug.Assert(serverViewModel.ShowAllProjects == true, "ShowAllProjects should have been set");
+                Debug.Assert(serverViewModel.ShowAllProjects, "ShowAllProjects should have been set");
                 this.SetProjectVMCommands(serverViewModel);
                 this.RestoreBoundProject(serverViewModel);
             }
@@ -562,7 +510,7 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
             this.BindCommand.ProgressControlHost = view;
         }
 
-        private void DetachView(IProgressControlHost view)
+        private void DetachView()
         {
             this.ConnectCommand.ProgressControlHost = null;
             this.BindCommand.ProgressControlHost = null;
@@ -578,7 +526,7 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
             this.BindCommand.UserNotification = vm;
         }
 
-        private void DetachViewModel(ConnectSectionViewModel vm)
+        private void DetachViewModel()
         {
             this.ConnectCommand.UserNotification = null;
             this.BindCommand.UserNotification = null;
@@ -594,12 +542,15 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
 
         #region IDisposable Support
 
+#pragma warning disable S2333 // Redundant modifiers should be removed, Justification: for test purposes
         protected virtual void Dispose(bool disposing)
+#pragma warning restore S2333 // Redundant modifiers should be removed
         {
             if (!this.isDisposed)
             {
                 if (disposing)
                 {
+                    this.State.PropertyChanged -= this.OnStatePropertyChanged;
                     this.ConnectCommand.ProjectsChanged -= this.SetProjects;
                     this.solutionTacker.ActiveSolutionChanged -= this.OnActiveSolutionChanged;
                 }

--- a/src/Integration/TeamExplorer/ConnectSectionView.xaml
+++ b/src/Integration/TeamExplorer/ConnectSectionView.xaml
@@ -40,17 +40,17 @@
 
         <ContentControl Name="progressPlacePlaceholder"/>
 
-        <StackPanel Visibility="{Binding ConnectedServers.Count, Converter={StaticResource IntToVisibleConverter}}">
+        <StackPanel Visibility="{Binding State.ConnectedServers.Count, Converter={StaticResource IntToVisibleConverter}}">
 
             <TextBlock Style="{StaticResource SQStaticTextStyle}"
                        Text="{x:Static resx:Strings.SelectSonarQubeProjectInstruction}"
                        TextWrapping="Wrap"
-                       Visibility="{Binding BoundProjects.Count, Converter={StaticResource IntToVisibleConverter}, ConverterParameter=Invert}"
+                       Visibility="{Binding State.HasBoundProject, Converter={StaticResource TrueToVisibleConverter}, ConverterParameter=Invert}"
                        Margin="0,0,0,6"/>
 
             <TreeView x:Name="ServerTreeView"
                       Margin="0,0,0,6"
-                      ItemsSource="{Binding ConnectedServers}"
+                      ItemsSource="{Binding State.ConnectedServers}"
                       Style="{StaticResource SQTreeViewStyle}"
                       ItemContainerStyle="{StaticResource SQServerTreeViewItemStyle}">
                 <TreeView.Resources>

--- a/src/Integration/TeamExplorer/ConnectSectionViewModel.cs
+++ b/src/Integration/TeamExplorer/ConnectSectionViewModel.cs
@@ -7,8 +7,8 @@
 
 using Microsoft.TeamFoundation.Controls;
 using Microsoft.TeamFoundation.Controls.WPF.TeamExplorer;
+using SonarLint.VisualStudio.Integration.State;
 using System;
-using System.Collections.ObjectModel;
 using System.Windows.Input;
 
 namespace SonarLint.VisualStudio.Integration.TeamExplorer
@@ -16,8 +16,7 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
     internal class ConnectSectionViewModel : TeamExplorerSectionViewModelBase,
                                         IUserNotification /* Most of it implemented by TeamExplorerSectionViewModelBase */
     {
-        private ObservableCollection<ServerViewModel> connectedServers;
-        private ObservableCollection<ProjectViewModel> boundProjects;
+        private TransferableVisualState state;
         private ICommand connectCommand;
         private ICommand bindCommand;
 
@@ -44,16 +43,10 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
 
         #region Properties
 
-        public ObservableCollection<ServerViewModel> ConnectedServers
+        public TransferableVisualState State
         {
-            get { return this.connectedServers; }
-            set { this.SetAndRaisePropertyChanged(ref this.connectedServers, value); }
-        }
-
-        public ObservableCollection<ProjectViewModel> BoundProjects
-        {
-            get { return this.boundProjects; }
-            set { this.SetAndRaisePropertyChanged(ref this.boundProjects, value); }
+            get { return this.state; }
+            set { this.SetAndRaisePropertyChanged(ref this.state, value); }
         }
 
         #endregion


### PR DESCRIPTION
The visual state needs to be transferable between TE sections navigation since the view and vm are disposed each time.
I've also simplified the tests, the API and removed the bound-projects (plural) concept and replaced it with a single HasBoundProject property which will work with WPF as long as the state API will be used to set/clear the bound project.

Misc: quite a few of the changes are because I resolved tech-debt issue coming from the analyzers in the modified files that I've touched.

I'll highlight the important changes