### PR TITLE
[SVS-20] Filter out VB.NET projects globally

### DIFF
--- a/src/Integration.UnitTests/ProjectSystemHelperTests.cs
+++ b/src/Integration.UnitTests/ProjectSystemHelperTests.cs
@@ -32,7 +32,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
         #region Tests
         [TestMethod]
-        public void ProjectSystemHelper_GetSolutionManagedProjects()
+        public void ProjectSystemHelper_GetSolutionManagedProjects_ReturnsOnlyCSharp()
         {
             // Setup
             ProjectMock csProject = this.solutionMock.AddOrGetProject("c#");
@@ -52,7 +52,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var actual = this.testSubject.GetSolutionManagedProjects().ToArray();
 
             // Verify
-            CollectionAssert.AreEqual(new[] { csProject, vbProject }, actual,
+            CollectionAssert.AreEqual(new[] { csProject }, actual,
                 "Unexpected projects: {0}", string.Join(", ", actual.Select(p => p.Name)));
         }
 

--- a/src/Integration/ProjectSystemHelper.cs
+++ b/src/Integration/ProjectSystemHelper.cs
@@ -177,7 +177,8 @@ namespace SonarLint.VisualStudio.Integration
 
         private static bool IsManagedProject(Project project)
         {
-            return IsCSharpProject(project) || IsVBProject(project);
+            // NB: We only support C# projects currently because the VB.NET plugin hasn't been updated.
+            return IsCSharpProject(project);
         }
 
         public static bool IsVBProject(Project project)


### PR DESCRIPTION
Globally filtering out VB.NET projects as a supported managed project.