### PR TITLE
[SVS-29] Add SonarQube invitation when not connected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ UnitTestResults.html
 # Visual Studio cache files
 *.sln.ide/
 
+# Visual Studio temp directories
+.vs/
+
 # Visual C++ cache files
 ipch/
 *.aps

--- a/src/Integration.UnitTests/Binding/BindCommandTests.cs
+++ b/src/Integration.UnitTests/Binding/BindCommandTests.cs
@@ -81,7 +81,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             });
 
             ThreadHelper.SetCurrentThreadAsUIThread();
-            var controller = new ConnectSectionController(new ServiceContainer(), new SonarQubeServiceWrapper(new ServiceContainer()), new ConfigurableActiveSolutionTracker());
+            var controller = new ConnectSectionController(new ServiceContainer(), new SonarQubeServiceWrapper(new ServiceContainer()), new ConfigurableActiveSolutionTracker(), new ConfigurableWebBrowser());
             Exceptions.Expect<ArgumentNullException>(() =>
             {
                 suppressAnalysisWarning = new BindCommand(controller, null);
@@ -384,7 +384,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         }
         private BindCommand CreateBindCommand()
         {
-            var controller = new ConnectSectionController(this.serviceProvider, new TransferableVisualState(), this.sonarQubeService, new ConfigurableActiveSolutionTracker(), Dispatcher.CurrentDispatcher);
+            var controller = new ConnectSectionController(this.serviceProvider, new TransferableVisualState(), this.sonarQubeService, new ConfigurableActiveSolutionTracker(), new ConfigurableWebBrowser(), Dispatcher.CurrentDispatcher);
             return new BindCommand(controller, this.sonarQubeService, this.workflow, this.projectSystemHelper);
         }
 

--- a/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
+++ b/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
@@ -466,7 +466,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var slnWriter = new SolutionRuleSetWriter(useProjectInfo, fileSystem);
             var useProjectWriter = projectWriter ?? new ProjectRuleSetWriter(fileSystem);
 
-            var controller = new ConnectSectionController(this.serviceProvider, new TransferableVisualState(), this.sonarQubeService, new ConfigurableActiveSolutionTracker(), Dispatcher.CurrentDispatcher);
+            var controller = new ConnectSectionController(this.serviceProvider, new TransferableVisualState(), this.sonarQubeService, new ConfigurableActiveSolutionTracker(), new ConfigurableWebBrowser(), Dispatcher.CurrentDispatcher);
 
             return new BindingWorkflow(controller.BindCommand, useProjectInfo, slnWriter, useProjectWriter, this.projectSystemHelper);
         }

--- a/src/Integration.UnitTests/Connection/ConnectCommandTests.cs
+++ b/src/Integration.UnitTests/Connection/ConnectCommandTests.cs
@@ -51,7 +51,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
             });
 
             ThreadHelper.SetCurrentThreadAsUIThread();
-            var controller = new ConnectSectionController(new ServiceContainer(), new SonarQubeServiceWrapper(new ServiceContainer()), new ConfigurableActiveSolutionTracker());
+            var controller = new ConnectSectionController(new ServiceContainer(), new SonarQubeServiceWrapper(new ServiceContainer()), new ConfigurableActiveSolutionTracker(), new ConfigurableWebBrowser());
             Exceptions.Expect<ArgumentNullException>(() =>
             {
                 suppressAnalysisIssue = new ConnectCommand(controller, null);
@@ -240,7 +240,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
         #region Helpers
         private ConnectCommand CreateTestSubject()
         {
-            var controller = new ConnectSectionController(this.serviceProvider, new TransferableVisualState(), this.sonarQubeService, new ConfigurableActiveSolutionTracker(), Dispatcher.CurrentDispatcher);
+            var controller = new ConnectSectionController(this.serviceProvider, new TransferableVisualState(), this.sonarQubeService, new ConfigurableActiveSolutionTracker(), new ConfigurableWebBrowser(), Dispatcher.CurrentDispatcher);
             return new ConnectCommand(controller, this.sonarQubeService, this.connectionProvider, this.connectionWorkflow);
         }
         #endregion

--- a/src/Integration.UnitTests/Connection/ConnectionWorkflowTests.cs
+++ b/src/Integration.UnitTests/Connection/ConnectionWorkflowTests.cs
@@ -110,7 +110,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
         public void ConnectionWorkflow_DontWarnAgainCanExec_NoSettings_IsFalse()
         {
             // Setup
-            var controller = new ConnectSectionController(new ConfigurableServiceProvider(false), new TransferableVisualState(), sonarQubeService, new ConfigurableActiveSolutionTracker(), Dispatcher.CurrentDispatcher);
+            var controller = new ConnectSectionController(new ConfigurableServiceProvider(false), new TransferableVisualState(), sonarQubeService, new ConfigurableActiveSolutionTracker(), new ConfigurableWebBrowser(), Dispatcher.CurrentDispatcher);
             var command = new ConnectCommand(controller, this.sonarQubeService);
             ConnectedProjectsCallback callback = (c, p) => { };
             var testSubject = new ConnectionWorkflow(command, callback);
@@ -219,7 +219,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
         #region Helpers
         private ConnectionWorkflow CreateTestSubject(ConnectedProjectsCallback projectsChanged, out ConnectCommand owningCommand)
         {
-            var controller = new ConnectSectionController(this.serviceProvider, new TransferableVisualState(), this.sonarQubeService, new ConfigurableActiveSolutionTracker(), Dispatcher.CurrentDispatcher);
+            var controller = new ConnectSectionController(this.serviceProvider, new TransferableVisualState(), this.sonarQubeService, new ConfigurableActiveSolutionTracker(), new ConfigurableWebBrowser(), Dispatcher.CurrentDispatcher);
             owningCommand = controller.ConnectCommand;
             return new ConnectionWorkflow(owningCommand, projectsChanged);
         }

--- a/src/Integration.UnitTests/TeamExplorer/ConnectSectionControllerTests.cs
+++ b/src/Integration.UnitTests/TeamExplorer/ConnectSectionControllerTests.cs
@@ -63,6 +63,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             Assert.AreSame(view, testSubject.BindCommand.ProgressControlHost);
             Assert.AreSame(testSubject.ConnectCommand.WpfCommand, vm.ConnectCommand);
             Assert.AreSame(testSubject.BindCommand.WpfCommand, vm.BindCommand);
+            Assert.AreSame(testSubject.BrowseToUrlCommand, vm.BrowseToUrlCommand);
         }
 
         [TestMethod]
@@ -143,6 +144,36 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
 
             // Verify
             Assert.AreSame(testSubject1.State, section1.ViewModel.State);
+        }
+
+        [TestMethod]
+        public void ConnectSectionController_BrowseToUrlCommand()
+        {
+            // Setup
+            var webBrowser = new ConfigurableWebBrowser();
+            var testSubject = new ConnectSectionController(this.serviceProvider,
+                new SonarQubeServiceWrapper(this.serviceProvider),
+                new ConfigurableActiveSolutionTracker(),
+                webBrowser);
+
+            // Case 1: Empty URL
+            // Act + Verify CanExecute
+            Assert.IsFalse(testSubject.BrowseToUrlCommand.CanExecute(null));
+
+            // Case 2: Bad URL
+            // Act + Verify CanExecute
+            Assert.IsFalse(testSubject.BrowseToUrlCommand.CanExecute("notaurl"));
+
+            // Case 3: Good URL
+            const string goodUrl = "http://localhost";
+
+            // Act + Verify CanExecute
+            Assert.IsTrue(testSubject.BrowseToUrlCommand.CanExecute(goodUrl));
+
+            // Act + Verify Execute
+            testSubject.BrowseToUrlCommand.Execute(goodUrl);
+            webBrowser.AssertNavigateToCalls(1);
+            webBrowser.AssertRequestToNavigateTo(goodUrl);
         }
 
         [TestMethod]
@@ -421,7 +452,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
 
         private ConnectSectionController CreateTestSubject(ConfigurableActiveSolutionTracker tracker)
         {
-            var controller = new TestableConnectSectionController(this.serviceProvider, new TransferableVisualState(), this.sonarQubeService, tracker);
+            var controller = new TestableConnectSectionController(this.serviceProvider, new TransferableVisualState(), this.sonarQubeService, tracker, new ConfigurableWebBrowser());
             controller.SetConnectCommand(new ConnectCommand(controller, this.sonarQubeService, null, this.workflow));
             return controller;
         }

--- a/src/Integration.UnitTests/TeamExplorer/ConnectSectionTests.cs
+++ b/src/Integration.UnitTests/TeamExplorer/ConnectSectionTests.cs
@@ -41,8 +41,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             // Constructor time initialization
             Assert.IsNotNull(testSubject.Controller.ConnectCommand, "ConnectCommand is not initialized");
             Assert.IsNotNull(testSubject.Controller.BindCommand, "BindCommand is not initialized");
+            Assert.IsNotNull(testSubject.Controller.BrowseToUrlCommand, "BrowseToUrlCommand is not initialized");
             Assert.IsNotNull(testSubject.Controller.DisconnectCommand, "DisconnectCommand is not initialized");
             Assert.IsNotNull(testSubject.Controller.RefreshCommand, "RefreshCommand is not initialized");
+            Assert.IsNotNull(testSubject.Controller.ToggleShowAllProjectsCommand, "ToggleShowAllProjectsCommand is not initialized");
 
             // Case 1: first time initialization
             // Verify

--- a/src/Integration.UnitTests/TeamExplorer/TestableConnectSectionController.cs
+++ b/src/Integration.UnitTests/TeamExplorer/TestableConnectSectionController.cs
@@ -18,15 +18,16 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
     {
         public TestableConnectSectionController(IServiceProvider serviceProvider,
                                                ISonarQubeServiceWrapper sonarQubeService)
-            : this(serviceProvider, new TransferableVisualState(), sonarQubeService, new ConfigurableActiveSolutionTracker())
+            : this(serviceProvider, new TransferableVisualState(), sonarQubeService, new ConfigurableActiveSolutionTracker(), new ConfigurableWebBrowser())
         {
         }
 
         public TestableConnectSectionController(IServiceProvider serviceProvider,
                                                 TransferableVisualState state,
                                                 ISonarQubeServiceWrapper sonarQubeService,
-                                                IActiveSolutionTracker tracker)
-            : base(serviceProvider, state, sonarQubeService, tracker, Dispatcher.CurrentDispatcher)
+                                                IActiveSolutionTracker tracker,
+                                                IWebBrowser webBrowser)
+            : base(serviceProvider, state, sonarQubeService, tracker, webBrowser, Dispatcher.CurrentDispatcher)
         {
         }
 

--- a/src/Integration/Constants.cs
+++ b/src/Integration/Constants.cs
@@ -28,5 +28,10 @@ namespace SonarLint.VisualStudio.Integration
         /// The property key which corresponds to the Roslyn analyzer additional files
         /// </summary>
         public const string AdditionalFilePropertyKey = "AdditionalFile";
+
+        /// <summary>
+        /// The SonarQube home page
+        /// </summary>
+        public const string SonarQubeHomeWebUrl = "http://sonarqube.org";
     }
 }

--- a/src/Integration/IWebBrowser.cs
+++ b/src/Integration/IWebBrowser.cs
@@ -1,0 +1,18 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="IWebBrowser.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace SonarLint.VisualStudio.Integration
+{
+    internal interface IWebBrowser
+    {
+        /// <summary>
+        /// Opens the current user's preferred web browser at the provided URL.
+        /// </summary>
+        /// <param name="url">URL to navigate to</param>
+        void NavigateTo(string url);
+    }
+}

--- a/src/Integration/Integration.csproj
+++ b/src/Integration/Integration.csproj
@@ -131,6 +131,7 @@
     <Compile Include="IActiveSolutionTracker.cs" />
     <Compile Include="IServiceProviderExtensions.cs" />
     <Compile Include="IIntegrationSettings.cs" />
+    <Compile Include="IWebBrowser.cs" />
     <Compile Include="Service\DataModel\ServerPlugin.cs" />
     <Compile Include="Service\RoslynExporter\AdditionalFile.cs" />
     <Compile Include="Service\RoslynExporter\Configuration.cs" />
@@ -188,6 +189,7 @@
     <Compile Include="TeamExplorer\ConnectSectionController.cs" />
     <Compile Include="TeamExplorer\IConnectSection.cs" />
     <Compile Include="TelemetryLoggerAccessor.cs" />
+    <Compile Include="WebBrowser.cs" />
     <Compile Include="WPF\ContextualCommandsCollection.cs" />
     <Compile Include="WPF\IconViewModel.cs" />
     <Compile Include="TeamExplorer\IUserNotification.cs" />

--- a/src/Integration/Resources/Strings.Designer.cs
+++ b/src/Integration/Resources/Strings.Designer.cs
@@ -414,6 +414,24 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to More info....
+        /// </summary>
+        public static string MoreInfoLinkText {
+            get {
+                return ResourceManager.GetString("MoreInfoLinkText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to http://sonarqube.org.
+        /// </summary>
+        public static string MoreInfoLinkUrl {
+            get {
+                return ResourceManager.GetString("MoreInfoLinkUrl", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Field can not be empty.
         /// </summary>
         public static string NotEmptyValidatorRequiredField {
@@ -446,6 +464,15 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         public static string PathHelperAbsolutePathExpected {
             get {
                 return ResourceManager.GetString("PathHelperAbsolutePathExpected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SonarSource and Microsoft.
+        /// </summary>
+        public static string ProductAuthors {
+            get {
+                return ResourceManager.GetString("ProductAuthors", resourceCulture);
             }
         }
         
@@ -591,6 +618,24 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         public static string ShowServerNuGetTrustWarningSettingName {
             get {
                 return ResourceManager.GetString("ShowServerNuGetTrustWarningSettingName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SonarQube is an open source platform to manage code quality. Connect your solution to an existing SonarQube Server to get the same issues in Visual Studio and in your SonarQube server..
+        /// </summary>
+        public static string SonarQubeDescription {
+            get {
+                return ResourceManager.GetString("SonarQubeDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SonarQube.
+        /// </summary>
+        public static string SonarQubeName {
+            get {
+                return ResourceManager.GetString("SonarQubeName", resourceCulture);
             }
         }
         

--- a/src/Integration/Resources/Strings.Designer.cs
+++ b/src/Integration/Resources/Strings.Designer.cs
@@ -423,15 +423,6 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to http://sonarqube.org.
-        /// </summary>
-        public static string MoreInfoLinkUrl {
-            get {
-                return ResourceManager.GetString("MoreInfoLinkUrl", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Field can not be empty.
         /// </summary>
         public static string NotEmptyValidatorRequiredField {

--- a/src/Integration/Resources/Strings.resx
+++ b/src/Integration/Resources/Strings.resx
@@ -417,10 +417,6 @@ Localization note: '[Don't warn me again]()' is a special markup used to transla
     <value>More info...</value>
     <comment>Link text for getting more information about SonarQube</comment>
   </data>
-  <data name="MoreInfoLinkUrl" xml:space="preserve">
-    <value>http://sonarqube.org</value>
-    <comment>Link URL for SonarQube's website</comment>
-  </data>
   <data name="ProductAuthors" xml:space="preserve">
     <value>SonarSource and Microsoft</value>
     <comment>Authors of the product</comment>

--- a/src/Integration/Resources/Strings.resx
+++ b/src/Integration/Resources/Strings.resx
@@ -413,4 +413,24 @@ Localization note: '[Don't warn me again]()' is a special markup used to transla
     <value>Unpacking additional file: {0}</value>
     <comment>Progress message indicating an additional files is being unpacked. {0} additional file name</comment>
   </data>
+  <data name="MoreInfoLinkText" xml:space="preserve">
+    <value>More info...</value>
+    <comment>Link text for getting more information about SonarQube</comment>
+  </data>
+  <data name="MoreInfoLinkUrl" xml:space="preserve">
+    <value>http://sonarqube.org</value>
+    <comment>Link URL for SonarQube's website</comment>
+  </data>
+  <data name="ProductAuthors" xml:space="preserve">
+    <value>SonarSource and Microsoft</value>
+    <comment>Authors of the product</comment>
+  </data>
+  <data name="SonarQubeDescription" xml:space="preserve">
+    <value>SonarQube is an open source platform to manage code quality. Connect your solution to an existing SonarQube Server to get the same issues in Visual Studio and in your SonarQube server.</value>
+    <comment>Short descriptive text about SonarQube shown on the Team Explorer invitiation card.</comment>
+  </data>
+  <data name="SonarQubeName" xml:space="preserve">
+    <value>SonarQube</value>
+    <comment>Name of SonarQube server product</comment>
+  </data>
 </root>

--- a/src/Integration/TeamExplorer/CommonStyles.xaml
+++ b/src/Integration/TeamExplorer/CommonStyles.xaml
@@ -149,7 +149,7 @@
             </DataTrigger>
         </Style.Triggers>
     </Style>
-
+    
     <Style x:Key="SQTreeViewIconStyle" TargetType="Image">
         <Setter Property="Height" Value="16"/>
         <Setter Property="Width" Value="16"/>

--- a/src/Integration/TeamExplorer/ConnectSectionView.xaml
+++ b/src/Integration/TeamExplorer/ConnectSectionView.xaml
@@ -29,14 +29,49 @@
     </UserControl.Resources>
 
     <StackPanel Style="{StaticResource SQTESectionStyle}">
-        <WrapPanel Style="{StaticResource SQActionListStyle}"
-                   Visibility="{Binding ElementName=ConnectLink, Path=IsEnabled, Converter={StaticResource TrueToVisibleConverter}}"
-                   Margin="0,0,0,6">
-            <tecontrols:TextLink x:Name="ConnectLink"
-                                 Text="{x:Static resx:Strings.ConnectLinkText}"
-                                 Command="{Binding ConnectCommand}"
-                                 CommandParameter="{Binding ElementName=progressPlacePlaceholder}"/>
-        </WrapPanel>
+
+        <StackPanel Visibility="{Binding State.ConnectedServers.Count, Converter={StaticResource IntToVisibleConverter}, ConverterParameter=Invert}"
+                    Margin="0,6,6,6">
+            <Grid Margin="0,0,0,6">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+                <Image Grid.Column="0"
+                       VerticalAlignment="Center"
+                       Width="32" Height="32"
+                       SnapsToDevicePixels="True"
+                       Margin="0,0,6,0"
+                       Source="{StaticResource SonarQubeServerIcon}"/>
+                <StackPanel Grid.Column="1"
+                            VerticalAlignment="Center">
+                    <TextBlock Text="{x:Static resx:Strings.SonarQubeName}"
+                               Style="{StaticResource EmphasizedText}"/>
+                    <TextBlock Text="{x:Static resx:Strings.ProductAuthors}"
+                               Style="{StaticResource SubduedText}"/>
+                </StackPanel>
+            </Grid>
+            <TextBlock Grid.Row="1"
+                       Margin="0,0,0,6"
+                       Text="{x:Static resx:Strings.SonarQubeDescription}"
+                       TextWrapping="Wrap"/>
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <tecontrols:TextLink Grid.Column="0"
+                                     x:Name="ConnectLink"
+                                     Text="{x:Static resx:Strings.ConnectLinkText}"
+                                     Command="{Binding ConnectCommand}"
+                                     CommandParameter="{Binding ElementName=progressPlacePlaceholder}"/>
+                <tecontrols:TextLink Grid.Column="2"
+                                     Text="{x:Static resx:Strings.MoreInfoLinkText}"
+                                     Command="{Binding BrowseToUrlCommand}"
+                                     CommandParameter="{x:Static resx:Strings.MoreInfoLinkUrl}"/>
+            </Grid>
+        </StackPanel>
 
         <ContentControl Name="progressPlacePlaceholder"/>
 

--- a/src/Integration/TeamExplorer/ConnectSectionView.xaml
+++ b/src/Integration/TeamExplorer/ConnectSectionView.xaml
@@ -14,6 +14,7 @@
              xmlns:local="clr-namespace:SonarLint.VisualStudio.Integration.TeamExplorer"
              xmlns:localWpf="clr-namespace:SonarLint.VisualStudio.Integration.WPF"
              xmlns:resx="clr-namespace:SonarLint.VisualStudio.Integration.Resources"
+             xmlns:root="clr-namespace:SonarLint.VisualStudio.Integration"
              mc:Ignorable="d" 
              d:DesignHeight="300" d:DesignWidth="300">
     <UserControl.Resources>
@@ -69,7 +70,7 @@
                 <tecontrols:TextLink Grid.Column="2"
                                      Text="{x:Static resx:Strings.MoreInfoLinkText}"
                                      Command="{Binding BrowseToUrlCommand}"
-                                     CommandParameter="{x:Static resx:Strings.MoreInfoLinkUrl}"/>
+                                     CommandParameter="{x:Static root:Constants.SonarQubeHomeWebUrl}"/>
             </Grid>
         </StackPanel>
 

--- a/src/Integration/TeamExplorer/ConnectSectionViewModel.cs
+++ b/src/Integration/TeamExplorer/ConnectSectionViewModel.cs
@@ -19,6 +19,7 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
         private TransferableVisualState state;
         private ICommand connectCommand;
         private ICommand bindCommand;
+        private ICommand browseToUrl;
 
         public ConnectSectionViewModel()
         {
@@ -63,6 +64,12 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
         {
             get { return this.bindCommand; }
             set { SetAndRaisePropertyChanged(ref this.bindCommand, value); }
+        }
+
+        public ICommand BrowseToUrlCommand
+        {
+            get { return this.browseToUrl; }
+            set { SetAndRaisePropertyChanged(ref this.browseToUrl, value); }
         }
 
         #endregion

--- a/src/Integration/WebBrowser.cs
+++ b/src/Integration/WebBrowser.cs
@@ -34,7 +34,7 @@ namespace SonarLint.VisualStudio.Integration
 
         private static bool IsSafeScheme(string scheme)
         {
-            return scheme.ToLowerInvariant().Contains("http");
+            return scheme.StartsWith("http", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/Integration/WebBrowser.cs
+++ b/src/Integration/WebBrowser.cs
@@ -1,0 +1,40 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="WebBrowser.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.ComponentModel.Composition;
+using System.Diagnostics;
+
+namespace SonarLint.VisualStudio.Integration
+{
+    [Export(typeof(IWebBrowser)), PartCreationPolicy(CreationPolicy.Shared)]
+    internal class WebBrowser : IWebBrowser
+    {
+        public void NavigateTo(string url)
+        {
+            Uri uri;
+            if (Uri.TryCreate(url, UriKind.Absolute, out uri) && IsSafeScheme(uri.Scheme))
+            {
+                var startInfo = new ProcessStartInfo(uri.AbsoluteUri)
+                {
+                    UseShellExecute = true
+                };
+
+                Process.Start(startInfo);
+            }
+            else
+            {
+                Debug.Fail("Provided URL was not in a correct format");
+            }
+        }
+
+        private static bool IsSafeScheme(string scheme)
+        {
+            return scheme.ToLowerInvariant().Contains("http");
+        }
+    }
+}

--- a/src/TestInfrastructure/Framework/ConfigurableWebBrowser.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableWebBrowser.cs
@@ -1,0 +1,39 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ConfigurableWebBrowser.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests
+{
+    public class ConfigurableWebBrowser : IWebBrowser
+    {
+        private readonly IList<string> navigatedUrls = new List<string>();
+
+        #region Test Helpers
+        public void AssertNavigateToCalls(int numCalls)
+        {
+            Assert.AreEqual(numCalls, this.navigatedUrls.Count, "Unexpected number of calls to NavigateTo");
+        }
+
+        public void AssertRequestToNavigateTo(string url)
+        {
+            Assert.IsTrue(navigatedUrls.Contains(url), $"URL '{url}' was not navigated to");
+        }
+
+        #endregion
+
+        #region IWebBrowser
+
+        void IWebBrowser.NavigateTo(string url)
+        {
+            this.navigatedUrls.Add(url);
+        }
+        
+        #endregion
+    }
+}

--- a/src/TestInfrastructure/TestInfrastructure.csproj
+++ b/src/TestInfrastructure/TestInfrastructure.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Framework\ConfigurableVsMonitorSelection.cs" />
     <Compile Include="Framework\ConfigurableVsProjectSystemHelper.cs" />
     <Compile Include="Framework\ConfigurableTelemetryLogger.cs" />
+    <Compile Include="Framework\ConfigurableWebBrowser.cs" />
     <Compile Include="Framework\ConfigurableWritableSettingsStore.cs" />
     <Compile Include="Helpers\AssertIgnoreScope.cs" />
     <Compile Include="Helpers\DispatcherHelper.cs" />


### PR DESCRIPTION
Invitation to connect/use SonarQube is shown on the Team Explorer SonarQube page > Connections section when there is no active server connection.
The card provides "Connect..." and "More info..." links.
Connect executes the connect command. More info executes a new command to
navigate to any URL using new IWebBrowser, passing the URL as a parameter.

Currently looks like this:
![invite](https://cloud.githubusercontent.com/assets/5658207/13497859/457e7b58-e14f-11e5-8d6b-9dcc3d0dd265.png)

With "More info..." taking you to http://sonarqube.org
