### PR TITLE
[SVS-5] Fix issues with adding Additional Files

### DIFF
--- a/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
+++ b/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
@@ -417,17 +417,17 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             string existingFullPath = Path.Combine(sonarDirPath, "foobar.xml");
             string existingRelativePath = PathHelper.CalculateRelativePath(project.FilePath, existingFullPath);
             var msbuildProject = new MSBuild.Project();
-            msbuildProject.AddItemFast(Constants.AdditionalFilePropertyKey, existingRelativePath);
+            msbuildProject.AddItemFast(Constants.AdditionalFilesPropertyKey, existingRelativePath);
             this.projectSystemHelper.MsBuildProjectMapping.Add(project, msbuildProject);
 
             // Sanity
-            Assert.AreEqual(1, msbuildProject.Items.Count(x => x.ItemType == Constants.AdditionalFilePropertyKey), "Expected 1 additional file in the project beforehand");
+            Assert.AreEqual(1, msbuildProject.Items.Count(x => x.ItemType == Constants.AdditionalFilesPropertyKey), "Expected 1 additional file in the project beforehand");
 
             // Act
             testSubject.InjectAdditionalFilesIntoProjects();
 
             // Verify
-            Assert.AreEqual(1, msbuildProject.Items.Count(x => x.ItemType == Constants.AdditionalFilePropertyKey), "Unexpected number of additional files; none should have been added/removed");
+            Assert.AreEqual(1, msbuildProject.Items.Count(x => x.ItemType == Constants.AdditionalFilesPropertyKey), "Unexpected number of additional files; none should have been added/removed");
         }
 
         [TestMethod]
@@ -523,7 +523,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             string relativePath = PathHelper.CalculateRelativePath(vsProject.FullName, additionalFilePath);
 
-            var additionalFileItems = msbuildProject.Items.Where(x => x.ItemType == Constants.AdditionalFilePropertyKey);
+            var additionalFileItems = msbuildProject.Items.Where(x => x.ItemType == Constants.AdditionalFilesPropertyKey);
 
             Assert.IsTrue(additionalFileItems.Select(x => x.UnevaluatedInclude).Contains(relativePath), $"AdditionalFile '{relativePath}' is missing");
         }

--- a/src/Integration.UnitTests/Integration.UnitTests.csproj
+++ b/src/Integration.UnitTests/Integration.UnitTests.csproj
@@ -37,7 +37,6 @@
     <CodeAnalysisRuleSet>Integration.UnitTests.Release.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\Packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>

--- a/src/Integration.UnitTests/ProjectSystemHelperTests.cs
+++ b/src/Integration.UnitTests/ProjectSystemHelperTests.cs
@@ -78,6 +78,19 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         }
 
         [TestMethod]
+        public void ProjectSystemHelper_IsFileInProject_DifferentCase()
+        {
+            // Setup
+            ProjectMock project = this.solutionMock.AddOrGetProject("project1");
+            string existingFile = "FILENAME";
+            string newFile = "filename";
+            project.AddOrGetFile(existingFile);
+
+            // Act + Verify
+            Assert.IsTrue(this.testSubject.IsFileInProject(project, newFile));
+        }
+
+        [TestMethod]
         public void ProjectSystemHelper_GetSolutionItemsProject()
         {
             // Setup

--- a/src/Integration/Binding/BindingWorkflow.cs
+++ b/src/Integration/Binding/BindingWorkflow.cs
@@ -396,7 +396,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
                     // Try and find all existing additional files, and fully resolve their full file paths
                     var existingFullPaths = new HashSet<string>(
                         from item in msBuildProject.Items
-                        where item.ItemType == Constants.AdditionalFilePropertyKey
+                        where item.ItemType == Constants.AdditionalFilesPropertyKey
                         select PathHelper.ResolveRelativePath(item.EvaluatedInclude, project.FullName),
                         StringComparer.OrdinalIgnoreCase);
 
@@ -405,7 +405,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
                     foreach (var fullPath in fullPathsToAdd)
                     {
                         string relativePath = PathHelper.CalculateRelativePath(projectRoot, fullPath);
-                        msBuildProject.AddItem(Constants.AdditionalFilePropertyKey, relativePath);
+                        msBuildProject.AddItem(Constants.AdditionalFilesPropertyKey, relativePath);
                     }
                 }
             }

--- a/src/Integration/Binding/BindingWorkflow.cs
+++ b/src/Integration/Binding/BindingWorkflow.cs
@@ -386,7 +386,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
             {
                 foreach (var additionalFilePath in this.AdditionalFilePaths)
                 {
-                    this.projectSystemHelper.AddFileToProject(project, additionalFilePath, Constants.AdditionalFilesPropertyKey);
+                    this.projectSystemHelper.AddFileToProject(project, additionalFilePath, Constants.AdditionalFilesItemTypeName);
                 }
             }
         }

--- a/src/Integration/Binding/BindingWorkflow.cs
+++ b/src/Integration/Binding/BindingWorkflow.cs
@@ -376,8 +376,11 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
         private void InjectAdditionalFiles()
         {
-            InjectAdditionalFilesIntoSolution();
-            InjectAdditionalFilesIntoProjects();
+            if (this.AdditionalFiles.Any())
+            {
+                InjectAdditionalFilesIntoSolution();
+                InjectAdditionalFilesIntoProjects();
+            }
         }
 
         internal /*for testing purposes*/ void InjectAdditionalFilesIntoProjects()

--- a/src/Integration/Constants.cs
+++ b/src/Integration/Constants.cs
@@ -27,7 +27,7 @@ namespace SonarLint.VisualStudio.Integration
         /// <summary>
         /// The property key which corresponds to the Roslyn analyzer additional files
         /// </summary>
-        public const string AdditionalFilePropertyKey = "AdditionalFile";
+        public const string AdditionalFilesPropertyKey = "AdditionalFiles";
 
         /// <summary>
         /// The SonarQube home page

--- a/src/Integration/Constants.cs
+++ b/src/Integration/Constants.cs
@@ -27,7 +27,7 @@ namespace SonarLint.VisualStudio.Integration
         /// <summary>
         /// The property key which corresponds to the Roslyn analyzer additional files
         /// </summary>
-        public const string AdditionalFilesPropertyKey = "AdditionalFiles";
+        public const string AdditionalFilesItemTypeName = "AdditionalFiles";
 
         /// <summary>
         /// The SonarQube home page

--- a/src/Integration/Constants.cs
+++ b/src/Integration/Constants.cs
@@ -33,5 +33,10 @@ namespace SonarLint.VisualStudio.Integration
         /// The SonarQube home page
         /// </summary>
         public const string SonarQubeHomeWebUrl = "http://sonarqube.org";
+
+        /// <summary>
+        /// The property key which correspsonds to the ItemType of a <see cref="EnvDTE.ProjectItem"/>.
+        /// </summary>
+        public const string ItemTypePropertyKey = "ItemType";
     }
 }

--- a/src/Integration/IProjectSystemHelper.cs
+++ b/src/Integration/IProjectSystemHelper.cs
@@ -25,8 +25,8 @@ namespace SonarLint.VisualStudio.Integration
 
         void AddFileToProject(Project project, string file);
 
-        IEnumerable<Project> GetSolutionManagedProjects();
+        void AddFileToProject(Project project, string file, string itemType);
 
-        Microsoft.Build.Evaluation.Project GetEquivalentMSBuildProject(EnvDTE.Project project);
+        IEnumerable<Project> GetSolutionManagedProjects();
     }
 }

--- a/src/Integration/Integration.csproj
+++ b/src/Integration/Integration.csproj
@@ -33,7 +33,6 @@
     <CodeAnalysisRuleSet>Integration.Release.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=2.20.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\Packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.20.301151232\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
       <Private>True</Private>

--- a/src/Integration/ProjectSystemHelper.cs
+++ b/src/Integration/ProjectSystemHelper.cs
@@ -111,6 +111,36 @@ namespace SonarLint.VisualStudio.Integration
             }
         }
 
+        public void AddFileToProject(Project project, string fullFilePath, string itemType)
+        {
+            if (project == null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
+
+            if (string.IsNullOrWhiteSpace(fullFilePath))
+            {
+                throw new ArgumentNullException(nameof(fullFilePath));
+            }
+
+            if (string.IsNullOrWhiteSpace(itemType))
+            {
+                throw new ArgumentNullException(nameof(itemType));
+            }
+
+            if (!this.IsFileInProject(project, fullFilePath))
+            {
+                ProjectItem item = project.ProjectItems.AddFromFile(fullFilePath);
+                Property itemTypeProperty = VsShellUtils.FindProperty(item.Properties, Constants.ItemTypePropertyKey);
+
+                Debug.Assert(itemTypeProperty != null, "Failed to set the ItemType of the project item");
+                if (itemTypeProperty != null)
+                {
+                    itemTypeProperty.Value = itemType;
+                }
+            }
+        }
+
         public Solution2 GetCurrentActiveSolution()
         {
             DTE dte = this.serviceProvider.GetService(typeof(DTE)) as DTE;
@@ -194,12 +224,6 @@ namespace SonarLint.VisualStudio.Integration
         private static bool IsProjectKind(Project project, string projectKindGuidString)
         {
             return StringComparer.OrdinalIgnoreCase.Equals(projectKindGuidString, project.Kind);
-        }
-
-        public Microsoft.Build.Evaluation.Project GetEquivalentMSBuildProject(Project project)
-        {
-            return Microsoft.Build.Evaluation.ProjectCollection.GlobalProjectCollection
-                .LoadedProjects.FirstOrDefault(p => StringComparer.OrdinalIgnoreCase.Equals(p.FullPath, project.FullName));
         }
     }
 }

--- a/src/Integration/VsShellUtils.cs
+++ b/src/Integration/VsShellUtils.cs
@@ -83,7 +83,7 @@ namespace SonarLint.VisualStudio.Integration
             }
         }
 
-        private static Property FindProperty(Properties properties, string propertyName)
+        public static Property FindProperty(Properties properties, string propertyName)
         {
             return properties?.OfType<Property>()
                 .Where(p => StringComparer.OrdinalIgnoreCase.Equals(p.Name, propertyName))

--- a/src/TestInfrastructure/Framework/ConfigurableVsProjectSystemHelper.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableVsProjectSystemHelper.cs
@@ -61,7 +61,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             if (addFileToProject)
             {
                 var item = project.ProjectItems.AddFromFile(file);
-                Property itemTypeProperty = item.Properties.Cast<Property>().FirstOrDefault(x => x.Name == Constants.ItemTypePropertyKey);
+                Property itemTypeProperty = VsShellUtils.FindProperty(item.Properties, Constants.ItemTypePropertyKey);
                 if (itemTypeProperty != null)
                 {
                     itemTypeProperty.Value = itemType;

--- a/src/TestInfrastructure/Framework/ConfigurableVsProjectSystemHelper.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableVsProjectSystemHelper.cs
@@ -17,8 +17,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
     {
         private readonly IServiceProvider serviceProvider;
 
-        public IDictionary<Project, Microsoft.Build.Evaluation.Project> MsBuildProjectMapping { get; } = new Dictionary<Project, Microsoft.Build.Evaluation.Project>();
-
         public ConfigurableVsProjectSystemHelper(IServiceProvider serviceProvider)
         {
             this.serviceProvider = serviceProvider;
@@ -57,19 +55,23 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             }
         }
 
+        void IProjectSystemHelper.AddFileToProject(Project project, string file, string itemType)
+        {
+            bool addFileToProject = !project.ProjectItems.OfType<ProjectItem>().Any(pi => StringComparer.OrdinalIgnoreCase.Equals(pi.Name, file));
+            if (addFileToProject)
+            {
+                var item = project.ProjectItems.AddFromFile(file);
+                Property itemTypeProperty = item.Properties.Cast<Property>().FirstOrDefault(x => x.Name == Constants.ItemTypePropertyKey);
+                if (itemTypeProperty != null)
+                {
+                    itemTypeProperty.Value = itemType;
+                }
+            }
+        }
+
         Solution2 IProjectSystemHelper.GetCurrentActiveSolution()
         {
             return this.CurrentActiveSolution;
-        }
-
-        Microsoft.Build.Evaluation.Project IProjectSystemHelper.GetEquivalentMSBuildProject(EnvDTE.Project project)
-        {
-            if (this.MsBuildProjectMapping.ContainsKey(project))
-            {
-                return this.MsBuildProjectMapping[project];
-            }
-
-            return null;
         }
 
         #endregion

--- a/src/TestInfrastructure/TestInfrastructure.csproj
+++ b/src/TestInfrastructure/TestInfrastructure.csproj
@@ -32,7 +32,6 @@
     <CodeAnalysisRuleSet>TestInfrastructure.Release.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\Packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
       <Private>True</Private>

--- a/src/TestInfrastructure/VsObjectModelMocks/ProjectItemsMock.cs
+++ b/src/TestInfrastructure/VsObjectModelMocks/ProjectItemsMock.cs
@@ -16,7 +16,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 {
     public class ProjectItemsMock : ProjectItems
     {
-        private List<ProjectItem> items = new List<ProjectItem>();
+        private readonly List<ProjectItem> items = new List<ProjectItem>();
 
         public ProjectItemsMock(ProjectMock parent, params ProjectItem[] items)
         {
@@ -125,11 +125,14 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         // Simplification over the exact structure
         internal class FileProjectItemMock : ProjectItem
         {
+            private readonly PropertiesMock properties;
+
             public FileProjectItemMock(ProjectItemsMock parent, string file)
             {
                 this.Parent = parent;
                 this.Name = file;
-                this.Properties = new PropertiesMock(this);
+                this.properties = new PropertiesMock(this);
+                this.properties.RegisterKnownProperty(Constants.ItemTypePropertyKey);
             }
 
             public ProjectItemsMock Parent
@@ -241,7 +244,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
             public Properties Properties
             {
-                get;
+                get { return this.properties; }
             }
 
             public bool Saved

--- a/src/TestInfrastructure/VsObjectModelMocks/PropertiesMock.cs
+++ b/src/TestInfrastructure/VsObjectModelMocks/PropertiesMock.cs
@@ -16,8 +16,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 {
     public class PropertiesMock : Properties
     {
-        private List<PropertyMock> properties = new List<PropertyMock>();
-        private object parent;
+        private readonly List<PropertyMock> properties = new List<PropertyMock>();
+        private readonly object parent;
 
         public PropertiesMock(object parent)
         {


### PR DESCRIPTION
@duncanpMS pointed out two issues, corrected both with these changes.
Issue 1: `AdditionalFiles` not `AdditionalFile` => renamed.
Issue 2: Files are not shown in Solution Explorer immediately => use EnvDTE object model rather than MSBuild.