### PR TITLE
[SVS-39] Fix issue around duplicate Includes in rule set files

### DIFF
--- a/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
+++ b/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
@@ -187,14 +187,15 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             string projectFullPath = Path.Combine(projectRoot, projectName + ".proj");
 
             string existingRuleSetPath = Path.Combine(projectRoot, "mycustomruleset.ruleset");
-            var existingRuleSet = new RuleSet(Constants.RuleSetName);
+            var existingRuleSet = TestRuleSetHelper.CreateTestRuleSet(existingRuleSetPath);
             existingRuleSet.Rules.Add(new RuleReference("testId", "testNs", "42", RuleAction.Default));
 
             var fileSystem = new ConfigurableRuleSetGenerationFileSystem();
             fileSystem.AddRuleSetFile(existingRuleSetPath, existingRuleSet);
+            fileSystem.AddRuleSetFile(solutionRuleSetPath, new RuleSet("sonar1"));
 
             string expectedRuleSetPath = existingRuleSetPath;
-            var expectedRuleSet = new RuleSet(Constants.RuleSetName);
+            var expectedRuleSet = TestRuleSetHelper.CreateTestRuleSet(expectedRuleSetPath);
             expectedRuleSet.RuleSetIncludes.Add(new RuleSetInclude(solutionRuleSetInclude, RuleAction.Default));
             expectedRuleSet.Rules.Add(new RuleReference("testId", "testNs", "42", RuleAction.Default));
 

--- a/src/Integration.UnitTests/Binding/ProjectRuleSetWriterTests.cs
+++ b/src/Integration.UnitTests/Binding/ProjectRuleSetWriterTests.cs
@@ -24,29 +24,49 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         public void ProjectRuleSetWriter_RemoveAllIncludesUnderRoot()
         {
             // Setup
-            const string removalRoot = @"X:\dirA\rootRemoveDir\";
+            const string slnRoot = @"X:\SolutionDir\";
+            string projectRoot = Path.Combine(slnRoot, @"Project\");
+            string sonarRoot = Path.Combine(slnRoot, @"Sonar\");
+            string commonRoot = Path.Combine(slnRoot, @"Common\");
 
-            const string notRemovedAbsolute = @"X:\should not be removed absolute.ruleset";
-            const string notRemovedRelative = @"..\..\should not be removed absolute.ruleset";
+            const string sonarRs1FileName      = "Sonar1.ruleset";
+            const string sonarRs2FileName      = "Sonar2.ruleset";
+            const string projectRsBaseFileName = "ProjectBase.ruleset";
+            const string commonRs1FileName     = "SolutionCommon1.ruleset";
+            const string commonRs2FileName     = "SolutionCommon2.ruleset";
 
-            const string removedAbsolute = @"X:\dirA\rootRemoveDir\sonarqube1.ruleset";
-            const string removedRelative = @"..\rootRemoveDir\sonarqube2.ruleset";
+            var sonarRs1      = TestRuleSetHelper.CreateTestRuleSet(sonarRoot, sonarRs1FileName);
+            var sonarRs2      = TestRuleSetHelper.CreateTestRuleSet(sonarRoot, sonarRs2FileName);
+            var projectBaseRs = TestRuleSetHelper.CreateTestRuleSet(projectRoot, projectRsBaseFileName);
+            var commonRs1     = TestRuleSetHelper.CreateTestRuleSet(commonRoot, commonRs1FileName);
+            var commonRs2     = TestRuleSetHelper.CreateTestRuleSet(commonRoot, commonRs2FileName);
 
-            var ruleSet = new RuleSet("Test");
-            ruleSet.RuleSetIncludes.Add(new RuleSetInclude(notRemovedAbsolute, RuleAction.Default));
-            ruleSet.RuleSetIncludes.Add(new RuleSetInclude(notRemovedRelative, RuleAction.Default));
-            ruleSet.RuleSetIncludes.Add(new RuleSetInclude(removedAbsolute, RuleAction.Default));
-            ruleSet.RuleSetIncludes.Add(new RuleSetInclude(removedRelative, RuleAction.Default));
+            var fs = new ConfigurableRuleSetGenerationFileSystem();
+            fs.AddRuleSetFile(sonarRs1.FilePath, sonarRs1);
+            fs.AddRuleSetFile(sonarRs2.FilePath, sonarRs2);
+            fs.AddRuleSetFile(projectBaseRs.FilePath, projectBaseRs);
+            fs.AddRuleSetFile(commonRs1.FilePath, commonRs1);
+            fs.AddRuleSetFile(commonRs2.FilePath, commonRs2);
 
-            var expectedRuleSet = new RuleSet("Test");
-            expectedRuleSet.RuleSetIncludes.Add(new RuleSetInclude(notRemovedAbsolute, RuleAction.Default));
-            expectedRuleSet.RuleSetIncludes.Add(new RuleSetInclude(notRemovedRelative, RuleAction.Default));
+            var inputRuleSet = TestRuleSetHelper.CreateTestRuleSet(projectRoot,  "test.ruleset");
+            AddRuleSetInclusion(inputRuleSet, projectBaseRs, useRelativePath: true);
+            AddRuleSetInclusion(inputRuleSet, commonRs1, useRelativePath: true);
+            AddRuleSetInclusion(inputRuleSet, commonRs2, useRelativePath: false);
+            AddRuleSetInclusion(inputRuleSet, sonarRs1, useRelativePath: true);
+            AddRuleSetInclusion(inputRuleSet, sonarRs2, useRelativePath: false);
+
+            var expectedRuleSet = TestRuleSetHelper.CreateTestRuleSet(projectRoot, "test.ruleset");
+            AddRuleSetInclusion(expectedRuleSet, projectBaseRs, useRelativePath: true);
+            AddRuleSetInclusion(expectedRuleSet, commonRs1, useRelativePath: true);
+            AddRuleSetInclusion(expectedRuleSet, commonRs2, useRelativePath: false);
+
+            var testSubject = new ProjectRuleSetWriter(fs);
 
             // Act
-            ProjectRuleSetWriter.RemoveAllIncludesUnderRoot(ruleSet, removalRoot);
+            testSubject.RemoveAllIncludesUnderRoot(inputRuleSet, sonarRoot);
 
             // Verify
-            RuleSetAssert.AreEqual(expectedRuleSet, ruleSet);
+            RuleSetAssert.AreEqual(expectedRuleSet, inputRuleSet);
         }
 
         [TestMethod]
@@ -245,13 +265,15 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             const string newSolutionRuleSetPath = @"X:\MySolution\SolutionRuleSets\sonarqube2.ruleset";
             const string expectedInclude = @"..\SolutionRuleSets\sonarqube2.ruleset";
 
-            var existingProjectRuleSet = new RuleSet("existing name");
+            var existingProjectRuleSet = TestRuleSetHelper.CreateTestRuleSet(existingProjectRuleSetPath);
             existingProjectRuleSet.RuleSetIncludes.Add(new RuleSetInclude(existingInclude, RuleAction.Default));
 
             fileSystem.AddRuleSetFile(existingProjectRuleSetPath, existingProjectRuleSet);
             long initalWriteTimestamp = fileSystem.GetFileTimestamp(existingProjectRuleSetPath);
 
-            var expectedRuleSet = new RuleSet("existing name");
+            fileSystem.AddRuleSetFile(@"X:\MySolution\SolutionRuleSets\sonarqube1.ruleset", new RuleSet("sonar1"));
+
+            var expectedRuleSet = TestRuleSetHelper.CreateTestRuleSet(existingProjectRuleSetPath);
             expectedRuleSet.RuleSetIncludes.Add(new RuleSetInclude(expectedInclude, RuleAction.Default));
 
             // Act
@@ -286,6 +308,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
                 numRules: 0,
                 includes: new[] { existingSolutionRuleSetInclude }
             );
+            existingRuleSet.FilePath = existingSolutionRuleSetPath;
+            fileSystem.AddRuleSetFile(existingSolutionRuleSetPath, existingRuleSet);
             fileSystem.AddRuleSetFile(projectRuleSetPath, existingRuleSet);
 
             string newSolutionRuleSetPath = Path.Combine(solutionRoot, "RuleSets", "sonar2.ruleset");
@@ -432,6 +456,18 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
             long afterTimestamp = fs.GetFileTimestamp(existingRuleSetFullPath);
             Assert.AreEqual(beforeTimestamp, afterTimestamp, "Rule set timestamp has changed; file was unexpectedly written to.");
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private static void AddRuleSetInclusion(RuleSet parent, RuleSet child, bool useRelativePath)
+        {
+            string include = useRelativePath
+                ? PathHelper.CalculateRelativePath(parent.FilePath, child.FilePath)
+                : child.FilePath;
+            parent.RuleSetIncludes.Add(new RuleSetInclude(include, RuleAction.Default));
         }
 
         #endregion

--- a/src/Integration.UnitTests/PathHelperTests.cs
+++ b/src/Integration.UnitTests/PathHelperTests.cs
@@ -248,6 +248,20 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             Assert.IsFalse(unrootedIsRooted, $"Path '{unrootedFile}' should not be rooted under '{root}'");
         }
 
+        [TestMethod]
+        public void PathHelper_IsPathRootedUnder_PathsContainRelativeComponents()
+        {
+            // Setup
+            const string root = @"X:\All\Files\..\Files\Live\Here";
+            const string rootedFile = @"X:\All\..\All\Files\Live\Here\likeme.ext";
+
+            // Act
+            bool rootedIsRooted = PathHelper.IsPathRootedUnderRoot(rootedFile, root);
+
+            // Verify
+            Assert.IsTrue(rootedIsRooted, $"Path '{rootedFile}' should be rooted under '{root}'");
+        }
+
         #region Helpers
 
         private static void VerifyCalculateRelativePath(string expected, string fromPath, string toPath)

--- a/src/Integration/Binding/ProjectRuleSetWriter.cs
+++ b/src/Integration/Binding/ProjectRuleSetWriter.cs
@@ -99,15 +99,17 @@ namespace SonarLint.VisualStudio.Integration.Binding
         /// <summary>
         /// Remove all rule set inclusions which exist under the specified root directory.
         /// </summary>
-        internal /* testing purposes */  static void RemoveAllIncludesUnderRoot(RuleSet ruleSet, string rootDirectory)
+        internal /* testing purposes */  void RemoveAllIncludesUnderRoot(RuleSet ruleSet, string rootDirectory)
         {
             Debug.Assert(!string.IsNullOrWhiteSpace(rootDirectory));
-            
+
+            string ruleSetRoot = PathHelper.ForceDirectoryEnding(Path.GetDirectoryName(ruleSet.FilePath));
+
             // List<T> required as RuleSetIncludes will be modified
             List<RuleSetInclude> toRemove = ruleSet.RuleSetIncludes
                                             .Where(include =>
                                             {
-                                                string fullIncludePath = PathHelper.ResolveRelativePath(include.FilePath, rootDirectory);
+                                                string fullIncludePath = PathHelper.ResolveRelativePath(include.FilePath, ruleSetRoot);
                                                 return PathHelper.IsPathRootedUnderRoot(fullIncludePath, rootDirectory);
                                             })
                                             .ToList();
@@ -125,7 +127,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
         {
             // Remove all solution level inclusions
             string solutionRuleSetRoot = PathHelper.ForceDirectoryEnding(Path.GetDirectoryName(solutionRuleSetPath));
-            RemoveAllIncludesUnderRoot(existingProjectRuleSet, solutionRuleSetRoot);
+            this.RemoveAllIncludesUnderRoot(existingProjectRuleSet, solutionRuleSetRoot);
 
             // Add correct inclusion
             string expectedIncludePath = PathHelper.CalculateRelativePath(projectRuleSetPath, solutionRuleSetPath);

--- a/src/Integration/PathHelper.cs
+++ b/src/Integration/PathHelper.cs
@@ -123,7 +123,10 @@ namespace SonarLint.VisualStudio.Integration
         {
             Debug.Assert(Path.IsPathRooted(path) || Path.IsPathRooted(rootDirectory), "Path should be absolute");
 
-            return path.StartsWith(rootDirectory, StringComparison.OrdinalIgnoreCase);
+            string expandedPath = Path.GetFullPath(path);
+            string expandedRootDirectory = Path.GetFullPath(rootDirectory);
+
+            return expandedPath.StartsWith(expandedRootDirectory, StringComparison.OrdinalIgnoreCase);
         }
 
         private static string ToFilePathString(Uri uri)

--- a/src/TestInfrastructure/Helpers/TestRuleSetHelper.cs
+++ b/src/TestInfrastructure/Helpers/TestRuleSetHelper.cs
@@ -13,6 +13,16 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 {
     internal static class TestRuleSetHelper
     {
+        public static RuleSet CreateTestRuleSet(string fullPath)
+        {
+            return new RuleSet(Constants.RuleSetName) { FilePath = fullPath };
+        }
+
+        public static RuleSet CreateTestRuleSet(string rootDir, string fileName)
+        {
+            return CreateTestRuleSet(Path.Combine(rootDir, fileName));
+        }
+
         public static RuleSet CreateTestRuleSet(int numRules, IEnumerable<string> includes = null)
         {
             var ruleSet = new RuleSet(Constants.RuleSetName);


### PR DESCRIPTION
Corrected an issue whereby when updating a project level rule set's
includes, the removal of old 'SonarQube' rule sets wasn't happening.
In fact it was (in some cases) removing other rule set includes NOT under
the SonarQube folder.

This was because the relative path resolution of the rule set include was
being done against the wrong base path. Also there was no check for
whether or not the computed path actually existed.

This issue manifested itself when binding with the Roslyn project.