### PR TITLE
[SVS-38] Alleviate file locking issues by reducing number of rule set writes

### DIFF
--- a/src/Integration.UnitTests/PathHelperTests.cs
+++ b/src/Integration.UnitTests/PathHelperTests.cs
@@ -100,6 +100,14 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
                 fromPath: @"X:\file with spaces (1).ext",
                 toPath: @"X:\file with spaces (2).ext"
             );
+
+            // Non canonical paths (contains . and ..)
+            VerifyCalculateRelativePath
+            (
+                expected: @"..\..\file1.ext",
+                fromPath: @"X:\dirA\..\dirA\dirB\dirC\dirD\",
+                toPath: @"X:\dirA\dirB\..\dirB\file1.ext"
+            );
         }
 
         [TestMethod]


### PR DESCRIPTION
For solutions which already had setup shared project-level rule sets, we were updating the rule set file once per project (with the same include).
This was causing unnecessary disk writes. As a result the IDE/Roslyn was reloading (with a lock for some reason) this file just as we are about to write to it again (for the next project).

Now keeping track of which existing rule sets we've already updated and skipping the update & write when we try with the same file again. This is OK since a new `ProjectRuleSetWriter` is created for each `BindingWorkflow` (which is per bind operation).