### PR TITLE
[SVS-47] Bind command is disabled until sln is fully loaded

### DIFF
--- a/src/Integration.UnitTests/Binding/BindCommandTests.cs
+++ b/src/Integration.UnitTests/Binding/BindCommandTests.cs
@@ -128,20 +128,26 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             ProjectViewModel projectVM = CreateProjectViewModel();
             BindCommand testSubject = this.PrepareCommandForExecution(new ConnectionInformation(new Uri("http://127.0.0.0")));
             ProjectMock project1 = this.solutionMock.Projects.Single();
-
-            // Case 1: SolutionExistsAndNotBuildingAndNotDebugging is not active
             testSubject.ProgressControlHost = new ConfigurableProgressControlHost();
+
+            // Case 1: SolutionExistsAndFullyLoaded is not active
+            this.monitorSelection.SetContext(VSConstants.UICONTEXT.SolutionExistsAndFullyLoaded_guid, false);
+            // Act + Verify
+            Assert.IsFalse(testSubject.WpfCommand.CanExecute(projectVM), "No UI context: SolutionExistsAndFullyLoaded");
+
+            // Case 2: SolutionExistsAndNotBuildingAndNotDebugging is not active
+            this.monitorSelection.SetContext(VSConstants.UICONTEXT.SolutionExistsAndFullyLoaded_guid, true);
             this.monitorSelection.SetContext(VSConstants.UICONTEXT.SolutionExistsAndNotBuildingAndNotDebugging_guid, false);
             // Act + Verify
-            Assert.IsFalse(testSubject.WpfCommand.CanExecute(projectVM), "No UI context");
+            Assert.IsFalse(testSubject.WpfCommand.CanExecute(projectVM), "No UI context: SolutionExistsAndNotBuildingAndNotDebugging");
 
-            // Case 2: Non-managed project kind
+            // Case 3: Non-managed project kind
             this.monitorSelection.SetContext(VSConstants.UICONTEXT.SolutionExistsAndNotBuildingAndNotDebugging_guid, true);
             this.projectSystemHelper.ManagedProjects = null;
             // Act + Verify
             Assert.IsFalse(testSubject.WpfCommand.CanExecute(projectVM), "No managed projects");
 
-            // Case 3: No projects at all
+            // Case 4: No projects at all
             solutionMock.RemoveProject(project1);
             // Act + Verify
             Assert.IsFalse(testSubject.WpfCommand.CanExecute(projectVM), "No projects");
@@ -356,6 +362,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             testSubject.UserNotification = notifications;
             this.sonarQubeService.SetConnection(connection);
             testSubject.ProgressControlHost = new ConfigurableProgressControlHost();
+            this.monitorSelection.SetContext(VSConstants.UICONTEXT.SolutionExistsAndFullyLoaded_guid, true);
             this.monitorSelection.SetContext(VSConstants.UICONTEXT.SolutionExistsAndNotBuildingAndNotDebugging_guid, true);
             ProjectMock project1 = this.solutionMock.AddOrGetProject("project1");
             this.projectSystemHelper.ManagedProjects = new[] { project1 };

--- a/src/Integration/Binding/BindCommand.cs
+++ b/src/Integration/Binding/BindCommand.cs
@@ -94,6 +94,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
                 && !this.Controller.State.IsBusy
                 && this.ProgressControlHost != null
                 && projectVM?.ProjectInformation != null
+                && VsShellUtils.IsSolutionExistsAndFullyLoaded()
                 && VsShellUtils.IsSolutionExistsAndNotBuildingAndNotDebugging()
                 && (this.projectSystemHelper.GetSolutionManagedProjects()?.Any() ?? false);
         }

--- a/src/Integration/VsShellUtils.cs
+++ b/src/Integration/VsShellUtils.cs
@@ -53,6 +53,16 @@ namespace SonarLint.VisualStudio.Integration
             return false;
         }
 
+        public static bool IsSolutionExistsAndFullyLoaded(Action onChange = null)
+        {
+            Debug.Assert(KnownUIContexts.SolutionExistsAndFullyLoadedContext != null, "KnownUIContexts.SolutionExistsAndFullyLoadedContext is null");
+            if (KnownUIContexts.SolutionExistsAndFullyLoadedContext != null)
+            {
+                return KnownUIContexts.SolutionExistsAndFullyLoadedContext.IsActive;
+            }
+            return false;
+        }
+
         public static void ActivateSolutionExplorer(IServiceProvider serviceProvider)
         {
             var dte = serviceProvider.GetService(typeof(DTE)) as DTE2;


### PR DESCRIPTION
Disabled the bind command until the UI context SolutionExistsAndIsFullyLoaded is also activated.