### PR TITLE
[SVS-43] Check for server plugin at connection step

### DIFF
--- a/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
+++ b/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
@@ -52,42 +52,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         #region Tests
 
         [TestMethod]
-        public void BindingWorkflow_VerifyServerPlugin_HasCSharpPlugin_DoesNotAbort()
-        {
-            // Setup
-            var testSubject = CreateTestSubject();
-            var progressExecEvents = new ConfigurableProgressStepExecutionEvents();
-            var progressController = new ConfigurableProgressController();
-            var plugin = new ServerPlugin { Key = ServerPlugin.CSharpPluginKey, Version = ServerPlugin.CSharpPluginMinimumVersion };
-            this.sonarQubeService.RegisterServerPlugin(plugin);
-
-            // Act
-            testSubject.VerifyServerPlugins(progressController, CancellationToken.None, progressExecEvents);
-
-            // Verify
-            progressController.AssertNumberOfAbortRequests(0);
-            this.outputWindowPane.AssertOutputStrings(0);
-        }
-
-        [TestMethod]
-        public void BindingWorkflow_VerifyServerPlugin_MissingCSharpPlugin_AbortsWorkflow()
-        {
-            // Setup
-            var testSubject = CreateTestSubject();
-            var progressExecEvents = new ConfigurableProgressStepExecutionEvents();
-            var progressController = new ConfigurableProgressController();
-            string expectedErrorMsg = string.Format(CultureInfo.CurrentCulture, Strings.ServerDoesNotHaveCorrectVersionOfCSharpPlugin, ServerPlugin.CSharpPluginMinimumVersion);
-
-            // Act
-            testSubject.VerifyServerPlugins(progressController, CancellationToken.None, progressExecEvents);
-
-            // Verify
-            progressController.AssertNumberOfAbortRequests(1);
-            this.outputWindowPane.AssertOutputStrings(1);
-            this.outputWindowPane.AssertOutputStrings(expectedErrorMsg);
-        }
-
-        [TestMethod]
         public void BindingWorkflow_DownloadQualityProfile_Success()
         {
             // Setup

--- a/src/Integration.UnitTests/Connection/ConnectionWorkflowTests.cs
+++ b/src/Integration.UnitTests/Connection/ConnectionWorkflowTests.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarLint.VisualStudio.Integration.Connection;
 using SonarLint.VisualStudio.Integration.Resources;
@@ -183,7 +184,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
 
             // Verify
             executionEvents.AssertProgressMessages(connectionMessage, Strings.ConnectionResultFailure);
-            Assert.IsFalse(projectChangedCallbackCalled, "ConnectedProjectsCallaback should not have been called");
+            Assert.IsFalse(projectChangedCallbackCalled, "Callback should have been called");
             this.sonarQubeService.AssertConnectRequests(1);
             Assert.IsNull(((ISonarQubeServiceWrapper)this.sonarQubeService).CurrentConnection, "Unexpected connection");
             notifications.AssertNotification(NotificationIds.FailedToConnectId, Strings.ConnectionFailed);
@@ -195,7 +196,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
 
             // Verify
             executionEvents.AssertProgressMessages(connectionMessage, Strings.ConnectionResultFailure);
-            Assert.IsFalse(projectChangedCallbackCalled, "ConnectedProjectsCallaback should not have been called");
+            Assert.IsFalse(projectChangedCallbackCalled, "Callback should have been called");
             this.sonarQubeService.AssertConnectRequests(2);
             Assert.IsNull(((ISonarQubeServiceWrapper)this.sonarQubeService).CurrentConnection, "Unexpected connection");
             notifications.AssertNotification(NotificationIds.FailedToConnectId, Strings.ConnectionFailed);
@@ -212,7 +213,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
 
             // Verify
             executionEvents.AssertProgressMessages(connectionMessage, Strings.ConnectionResultCancellation);
-            Assert.IsFalse(projectChangedCallbackCalled, "ConnectedProjectsCallaback should not have been called");
+            Assert.IsFalse(projectChangedCallbackCalled, "Callback should have been called");
             this.sonarQubeService.AssertConnectRequests(3);
             Assert.IsNull(((ISonarQubeServiceWrapper)this.sonarQubeService).CurrentConnection, "Unexpected connection");
             notifications.AssertNotification(NotificationIds.FailedToConnectId, Strings.ConnectionFailed);
@@ -240,7 +241,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
             testSubject.ConnectionStep(controller, CancellationToken.None, connectionInfo, executionEvents);
 
             // Verify
-            this.sonarQubeService.AssertDisconnectRequests(1);
             controller.AssertNumberOfAbortRequests(1);
             executionEvents.AssertProgressMessages(
                 connectionInfo.ServerUri.ToString(),

--- a/src/Integration.UnitTests/Connection/ConnectionWorkflowTests.cs
+++ b/src/Integration.UnitTests/Connection/ConnectionWorkflowTests.cs
@@ -184,7 +184,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
 
             // Verify
             executionEvents.AssertProgressMessages(connectionMessage, Strings.ConnectionResultFailure);
-            Assert.IsFalse(projectChangedCallbackCalled, "Callback should have been called");
+            Assert.IsFalse(projectChangedCallbackCalled, "Callback should not have been called");
             this.sonarQubeService.AssertConnectRequests(1);
             Assert.IsNull(((ISonarQubeServiceWrapper)this.sonarQubeService).CurrentConnection, "Unexpected connection");
             notifications.AssertNotification(NotificationIds.FailedToConnectId, Strings.ConnectionFailed);
@@ -196,7 +196,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
 
             // Verify
             executionEvents.AssertProgressMessages(connectionMessage, Strings.ConnectionResultFailure);
-            Assert.IsFalse(projectChangedCallbackCalled, "Callback should have been called");
+            Assert.IsFalse(projectChangedCallbackCalled, "Callback should not have been called");
             this.sonarQubeService.AssertConnectRequests(2);
             Assert.IsNull(((ISonarQubeServiceWrapper)this.sonarQubeService).CurrentConnection, "Unexpected connection");
             notifications.AssertNotification(NotificationIds.FailedToConnectId, Strings.ConnectionFailed);
@@ -213,7 +213,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
 
             // Verify
             executionEvents.AssertProgressMessages(connectionMessage, Strings.ConnectionResultCancellation);
-            Assert.IsFalse(projectChangedCallbackCalled, "Callback should have been called");
+            Assert.IsFalse(projectChangedCallbackCalled, "Callback should not have been called");
             this.sonarQubeService.AssertConnectRequests(3);
             Assert.IsNull(((ISonarQubeServiceWrapper)this.sonarQubeService).CurrentConnection, "Unexpected connection");
             notifications.AssertNotification(NotificationIds.FailedToConnectId, Strings.ConnectionFailed);

--- a/src/Integration/Binding/BindingWorkflow.cs
+++ b/src/Integration/Binding/BindingWorkflow.cs
@@ -38,7 +38,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
         {
             {SonarQubeServiceWrapper.CSharpLanguage, RuleSetGroup.CSharp },
             {SonarQubeServiceWrapper.VBLanguage, RuleSetGroup.VB }
-        };
+        };        
 
         public BindingWorkflow(BindCommand owner, ProjectInformation project)
             : this(owner, project, null)
@@ -141,9 +141,6 @@ namespace SonarLint.VisualStudio.Integration.Binding
                 new ProgressStepDefinition(null, StepAttributes.Indeterminate | StepAttributes.Hidden,
                         (token, notifications) => this.PromptSaveSolutionIfDirty(controller, token)),
 
-                new ProgressStepDefinition(null, StepAttributes.BackgroundThread | StepAttributes.Hidden | StepAttributes.Indeterminate,
-                        (token, notifications) => this.VerifyServerPlugins(controller, token, notifications)),
-
                 new ProgressStepDefinition(Strings.BindingProjectsDisplayMessage, StepAttributes.BackgroundThread,
                         (token, notifications) => this.DownloadQualityProfile(controller, token, notifications, languages)),
 
@@ -186,18 +183,6 @@ namespace SonarLint.VisualStudio.Integration.Binding
         {
             bool saved = VsShellUtils.SaveSolution(this.owner.ServiceProvider, silent: true);
             Debug.Assert(saved, "Should not be cancellable");
-        }
-
-        internal /*for testing purposes*/ void VerifyServerPlugins(IProgressController controller, CancellationToken token, IProgressStepExecutionEvents notifications)
-        {
-            var csPluginVersion = this.owner.SonarQubeService.GetPluginVersion(ServerPlugin.CSharpPluginKey, token);
-            if (string.IsNullOrWhiteSpace(csPluginVersion) || VersionHelper.Compare(csPluginVersion, ServerPlugin.CSharpPluginMinimumVersion) < 0)
-            {
-                string errorMessage = string.Format(CultureInfo.CurrentCulture, Strings.ServerDoesNotHaveCorrectVersionOfCSharpPlugin, ServerPlugin.CSharpPluginMinimumVersion);
-                VsShellUtils.WriteToGeneralOutputPane(this.owner.ServiceProvider, errorMessage);
-
-                this.AbortWorkflow(controller, token);
-            }
         }
 
         internal /*for testing purposes*/ void DownloadQualityProfile(IProgressController controller, CancellationToken cancellationToken, IProgressStepExecutionEvents notificationEvents, IEnumerable<string> languages)
@@ -334,7 +319,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
         }
 
         internal /*for testing purposes*/ void EmitBindingCompleteMessage(IProgressStepExecutionEvents notifications)
-        {
+            {
             var message = this.AllNuGetPackagesInstalled
                 ? Strings.FinishedSolutionBindingWorkflowSuccessful
                 : Strings.FinishedSolutionBindingWorkflowNotAllPackagesInstalled;

--- a/src/Integration/Connection/ConnectionWorkflow.cs
+++ b/src/Integration/Connection/ConnectionWorkflow.cs
@@ -109,6 +109,30 @@ namespace SonarLint.VisualStudio.Integration.Connection
 
             notifications.ProgressChanged(connection.ServerUri.ToString(), double.NaN);
 
+            var plugins = this.owner.SonarQubeService.GetPlugins(connection, cancellationToken);
+
+            if (plugins == null)
+            {
+                notifications.ProgressChanged(cancellationToken.IsCancellationRequested ? Strings.ConnectionResultCancellation : Strings.ConnectionResultFailure, double.NaN);
+                this.owner.UserNotification?.ShowNotificationError(Strings.ConnectionFailed, NotificationIds.FailedToConnectId, this.owner.WpfCommand);
+
+                AbortWorkflow(controller, cancellationToken);
+                return;
+            }
+
+            var csPlugin = plugins.FirstOrDefault(x => StringComparer.Ordinal.Equals(x.Key, ServerPlugin.CSharpPluginKey));
+            if (string.IsNullOrWhiteSpace(csPlugin?.Version) || VersionHelper.Compare(csPlugin.Version, ServerPlugin.CSharpPluginMinimumVersion) < 0)
+            {
+                string errorMessage = string.Format(CultureInfo.CurrentCulture, Strings.ServerDoesNotHaveCorrectVersionOfCSharpPlugin, ServerPlugin.CSharpPluginMinimumVersion);
+
+                this.owner.UserNotification?.ShowNotificationError(errorMessage, NotificationIds.BadServerPluginId, null);
+                notifications.ProgressChanged(errorMessage, double.NaN);
+                notifications.ProgressChanged(Strings.ConnectionResultFailure, double.NaN);
+
+                AbortWorkflow(controller, cancellationToken);
+                return;
+            }
+
             ProjectInformation[] projects = this.owner.SonarQubeService.Connect(connection, cancellationToken)?.ToArray();
 
             if (this.owner.SonarQubeService.CurrentConnection == null)
@@ -119,24 +143,9 @@ namespace SonarLint.VisualStudio.Integration.Connection
                 AbortWorkflow(controller, cancellationToken);
                 return;
             }
-            
-            var csPluginVersion = this.owner.SonarQubeService.GetPluginVersion(ServerPlugin.CSharpPluginKey, cancellationToken);
-            if (string.IsNullOrWhiteSpace(csPluginVersion) || VersionHelper.Compare(csPluginVersion, ServerPlugin.CSharpPluginMinimumVersion) < 0)
-            {
-                string errorMessage = string.Format(CultureInfo.CurrentCulture, Strings.ServerDoesNotHaveCorrectVersionOfCSharpPlugin, ServerPlugin.CSharpPluginMinimumVersion);
-
-                this.owner.UserNotification?.ShowNotificationError(errorMessage, NotificationIds.BadServerPluginId, this.owner.WpfCommand);
-                notifications.ProgressChanged(errorMessage, double.NaN);
-                notifications.ProgressChanged(Strings.ConnectionResultFailure, double.NaN);
-
-                this.owner.SonarQubeService.Disconnect();
-
-                AbortWorkflow(controller, cancellationToken);
-                return;
-            }
 
             this.OnProjectsChanged(connection, projects);
-            notifications.ProgressChanged(Strings.ConnectionResultSuccess, double.NaN);            
+            notifications.ProgressChanged(Strings.ConnectionResultSuccess, double.NaN);
         }
 
         internal /* for testing purposes */ void ShowNuGetWarning()

--- a/src/Integration/Resources/Strings.Designer.cs
+++ b/src/Integration/Resources/Strings.Designer.cs
@@ -549,7 +549,7 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Connection failed. The server does not have the minimum required version ({0}) of the C# plugin installed..
+        ///   Looks up a localized string similar to The specified server does not have the minimum required version ({0}) of the C# plugin installed. Please contact your SonarQube server administrator..
         /// </summary>
         public static string ServerDoesNotHaveCorrectVersionOfCSharpPlugin {
             get {

--- a/src/Integration/Resources/Strings.Designer.cs
+++ b/src/Integration/Resources/Strings.Designer.cs
@@ -549,7 +549,7 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to SonarQube project binding failed: The server does not have the minimum required version ({0}) of the C# plugin installed..
+        ///   Looks up a localized string similar to Connection failed. The server does not have the minimum required version ({0}) of the C# plugin installed..
         /// </summary>
         public static string ServerDoesNotHaveCorrectVersionOfCSharpPlugin {
             get {

--- a/src/Integration/Resources/Strings.resx
+++ b/src/Integration/Resources/Strings.resx
@@ -398,7 +398,7 @@ Localization note: '[Don't warn me again]()' is a special markup used to transla
     <comment>Exception message indicating that the provided version string is malformed and cannot be compared. {0} version string</comment>
   </data>
   <data name="ServerDoesNotHaveCorrectVersionOfCSharpPlugin" xml:space="preserve">
-    <value>Connection failed. The server does not have the minimum required version ({0}) of the C# plugin installed.</value>
+    <value>The specified server does not have the minimum required version ({0}) of the C# plugin installed. Please contact your SonarQube server administrator.</value>
     <comment>Error message indicating that the server does not have the required version of the C# plugin installed. {0} minimum required version</comment>
   </data>
   <data name="FailedToUnpackAdditionalFiles" xml:space="preserve">

--- a/src/Integration/Resources/Strings.resx
+++ b/src/Integration/Resources/Strings.resx
@@ -398,7 +398,7 @@ Localization note: '[Don't warn me again]()' is a special markup used to transla
     <comment>Exception message indicating that the provided version string is malformed and cannot be compared. {0} version string</comment>
   </data>
   <data name="ServerDoesNotHaveCorrectVersionOfCSharpPlugin" xml:space="preserve">
-    <value>SonarQube project binding failed: The server does not have the minimum required version ({0}) of the C# plugin installed.</value>
+    <value>Connection failed. The server does not have the minimum required version ({0}) of the C# plugin installed.</value>
     <comment>Error message indicating that the server does not have the required version of the C# plugin installed. {0} minimum required version</comment>
   </data>
   <data name="FailedToUnpackAdditionalFiles" xml:space="preserve">

--- a/src/Integration/Service/ISonarQubeServiceWrapper.cs
+++ b/src/Integration/Service/ISonarQubeServiceWrapper.cs
@@ -5,6 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using SonarLint.VisualStudio.Integration.Service.DataModel;
 using System.Collections.Generic;
 using System.Threading;
 
@@ -44,10 +45,10 @@ namespace SonarLint.VisualStudio.Integration.Service
         RoslynExportProfile GetExportProfile(ProjectInformation project, string language, CancellationToken token);
 
         /// <summary>
-        /// Retrieves the version of the specified server plugin based on its <paramref name="pluginKey"/>.
+        /// Retrieves all server plugins for the given <paramref name="connectionInformation"/>.
         /// </summary>
-        /// <param name="pluginKey">Key of the server plugin</param>
-        /// <returns>The version string of the plugin, or null if it is not installed</returns>
-        string GetPluginVersion(string pluginKey, CancellationToken token);
+        /// <param name="connectionInformation">Required connecting information</param>
+        /// <returns>All server plugins, or null on connection failure</returns>
+        IEnumerable<ServerPlugin> GetPlugins(ConnectionInformation connectionInformation, CancellationToken token);
     }
 }

--- a/src/Integration/Service/SonarQubeServiceWrapper.cs
+++ b/src/Integration/Service/SonarQubeServiceWrapper.cs
@@ -117,18 +117,17 @@ namespace SonarLint.VisualStudio.Integration.Service
                 client => this.DownloadExportForProject(client, project, language, token));
         }
 
-        public string GetPluginVersion(string pluginKey, CancellationToken token)
+        public IEnumerable<ServerPlugin> GetPlugins(ConnectionInformation connectionInformation, CancellationToken token)
         {
-            if (string.IsNullOrWhiteSpace(pluginKey))
+            if (connectionInformation == null)
             {
-                throw new ArgumentNullException(nameof(pluginKey));
+                throw new ArgumentNullException(nameof(connectionInformation));
             }
 
-            ServerPlugin[] plugins = this.SafeUseHttpClient<ServerPlugin[]>(this.CurrentConnection,
+            ServerPlugin[] plugins = this.SafeUseHttpClient<ServerPlugin[]>(connectionInformation,
                 client => DownloadPluginInformation(client, token));
 
-            var plugin = plugins?.FirstOrDefault(x => StringComparer.Ordinal.Equals(x.Key, pluginKey));
-            return plugin?.Version;
+            return plugins;
         }
 
         #endregion

--- a/src/Integration/TeamExplorer/NotificationIds.cs
+++ b/src/Integration/TeamExplorer/NotificationIds.cs
@@ -15,5 +15,6 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
         public static readonly Guid FailedToBindId = new Guid("5A38773F-89F6-49ED-8B67-1A82A8182589");
         public static readonly Guid FailedToFindBoundProjectKeyId = new Guid("4A92944A-2585-442D-8821-DE235DA9E478");
         public static readonly Guid WarnServerTrustId = new Guid("{F9A383D5-47ED-439E-A1DB-7A1083062CCD}");
+        public static readonly Guid BadServerPluginId = new Guid("{F89A8FAB-6EF1-4EB5-A1F7-A197AEF9DC8C}");
     }
 }

--- a/src/TestInfrastructure/Framework/ConfigurableProgressStepExecutionEvents.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableProgressStepExecutionEvents.cs
@@ -31,7 +31,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         public void AssertProgressMessages(params string[] expectedOrderedMessages)
         {
             string[] actualMessages = this.progressEventsMessages.Select(kv => kv.Item1).ToArray();
-            CollectionAssert.AreEqual(expectedOrderedMessages, actualMessages, "Unexpected messages :{0}", string.Join(", ", actualMessages));
+            CollectionAssert.AreEqual(expectedOrderedMessages, actualMessages, "Unexpected messages: {0}", string.Join(", ", actualMessages));
         }
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         public void AssertProgress(params double[] expectedProgress)
         {
             double[] actualProgress = this.progressEventsMessages.Select(kv => kv.Item2).ToArray();
-            CollectionAssert.AreEqual(expectedProgress, actualProgress, "Unexpected progress :{0}", string.Join(", ", actualProgress));
+            CollectionAssert.AreEqual(expectedProgress, actualProgress, "Unexpected progress: {0}", string.Join(", ", actualProgress));
         }
 
         public void Reset()

--- a/src/TestInfrastructure/Framework/ConfigurableSonarQubeServiceWrapper.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableSonarQubeServiceWrapper.cs
@@ -70,6 +70,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             this.ServerPlugins[plugin.Key] = plugin;
         }
 
+        public void ClearServerPlugins()
+        {
+            this.ServerPlugins.Clear();
+        }
+
         #endregion
 
         #region ISonarQubeServiceWrapper

--- a/src/TestInfrastructure/Framework/ConfigurableSonarQubeServiceWrapper.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableSonarQubeServiceWrapper.cs
@@ -17,8 +17,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
     internal class ConfigurableSonarQubeServiceWrapper : ISonarQubeServiceWrapper
     {
         private ConnectionInformation connection;
-        private int connectRequestsCount = 0;
-        private int disconnectRequestsCount = 0;
+        private int connectRequestsCount;
+        private int disconnectRequestsCount;
 
         #region Testing helpers
         public bool AllowConnections { get; set; } = true;
@@ -122,11 +122,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             return export;
         }
 
-        public string GetPluginVersion(string pluginKey, CancellationToken token)
+        public IEnumerable<ServerPlugin> GetPlugins(ConnectionInformation connectionInformation, CancellationToken token)
         {
-            ServerPlugin plugin = null;
-            this.ServerPlugins.TryGetValue(pluginKey, out plugin);
-            return plugin?.Version;
+            return this.ServerPlugins.Values;
         }
 
         #endregion


### PR DESCRIPTION
Instead of checking as a step in the `BindingWorkflow`, now do the check as part of the `ConnectionStep` of the `ConnectionWorkflow`.

In the event that the server does not have the correct plugin version, a Team Explorer notification is shown and the workflow is aborted.