### PR TITLE
[SVS-58] Test project detection and project exclusion

### DIFF
--- a/src/Integration.UnitTests/Binding/BindingControllerTests.cs
+++ b/src/Integration.UnitTests/Binding/BindingControllerTests.cs
@@ -120,7 +120,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
 
             // Case 3: Non-managed project kind
             this.monitorSelection.SetContext(VSConstants.UICONTEXT.SolutionExistsAndNotBuildingAndNotDebugging_guid, true);
-            this.projectSystemHelper.ManagedProjects = null;
+            this.projectSystemHelper.Projects = null;
             // Act + Verify
             Assert.IsFalse(testSubject.BindCommand.CanExecute(projectVM), "No managed projects");
 
@@ -305,7 +305,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             this.monitorSelection.SetContext(VSConstants.UICONTEXT.SolutionExistsAndFullyLoaded_guid, true);
             this.monitorSelection.SetContext(VSConstants.UICONTEXT.SolutionExistsAndNotBuildingAndNotDebugging_guid, true);
             ProjectMock project1 = this.solutionMock.AddOrGetProject("project1");
-            this.projectSystemHelper.ManagedProjects = new[] { project1 };
+            this.projectSystemHelper.Projects = new[] { project1 };
 
             // Sanity
             Assert.IsTrue(testSubject.BindCommand.CanExecute(CreateProjectViewModel()), "All the requirement should be satisfied for the command to be enabled");

--- a/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
+++ b/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
@@ -284,7 +284,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         }
 
         [TestMethod]
-        public void BindingWorkflow_GetBindingLangauges_ReturnsDistinctLanguagesForProjects()
+        public void BindingWorkflow_GetBindingLanguages_ReturnsDistinctLanguagesForProjects()
         {
             // Setup
             var testSubject = this.CreateTestSubject();
@@ -315,7 +315,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var actualLanguages = testSubject.GetBindingLanguages();
 
             // Verify
-            CollectionAssert.AreEqual(expectedLanguages, actualLanguages.ToArray(), "Unexpected lanuages for binding projects");
+            CollectionAssert.AreEquivalent(expectedLanguages, actualLanguages.ToArray(), "Unexpected lanuages for binding projects");
         }
 
         [TestMethod]
@@ -366,6 +366,32 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             progressEvents.AssertProgressMessages(Strings.PreparingBindingWorkflowProgessMessage);
         }
 
+        [TestMethod]
+        public void BindingWorkflow_DownloadBindingParameters_InvalidRegex_UsesDefault()
+        {
+            // Setup
+            var filter = new ConfigurableProjectSystemFilter();
+            var controller = new ConfigurableProgressController();
+            var progressEvents = new ConfigurableProgressStepExecutionEvents();
+
+            var badExpression = "*-gf/d*-b/try\\*-/r-*yeb/\\";
+            var expectedExpression = ServerProperty.TestProjectRegexDefaultValue;
+            this.sonarQubeService.RegisterServerProperty(new ServerProperty
+            {
+                Key = ServerProperty.TestProjectRegexKey,
+                Value = badExpression
+            });
+
+            var testSubject = this.CreateTestSubject(filter: filter);
+
+            // Act
+            testSubject.DownloadBindingParameters(controller, CancellationToken.None, progressEvents);
+
+            // Verify
+            filter.AssertTestRegex(expectedExpression, RegexOptions.IgnoreCase);
+            progressEvents.AssertProgressMessages(Strings.PreparingBindingWorkflowProgessMessage);
+            this.outputWindowPane.AssertOutputStrings(string.Format(CultureInfo.CurrentCulture, Strings.InvalidTestProjectRegexPattern, badExpression));
+        }
 
         [TestMethod]
         public void BindingWorkflow_DownloadBindingParameters_Cancelled_AbortsWorkflow()

--- a/src/Integration.UnitTests/Binding/ProjectSystemFilterTests.cs
+++ b/src/Integration.UnitTests/Binding/ProjectSystemFilterTests.cs
@@ -30,6 +30,16 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         #region Tests 
 
         [TestMethod]
+        public void ProjectSystemFilter_IsAccepted_ArgumentChecks()
+        {
+            // Setup
+            var testSubject = this.CreateTestSubject();
+
+            // Act + Verify
+            Exceptions.Expect<ArgumentNullException>(() => testSubject.IsAccepted(null));
+        }
+
+        [TestMethod]
         public void ProjectSystemFilter_IsAccepted_UnsupportedLanguage_IsFalse()
         {
             // Setup
@@ -54,17 +64,34 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             var project = new ProjectMock("supported.csproj");
             project.SetCSProjectKind();
 
-            // Test case 1: property true -> not accepted
-            // Setup
-            project.SetBuildProperty(Constants.SonarQubeExcludeBuildPropertyKey, "true");
-            
+            // Test case 1: property false -> is accepted
             // Act
             var result = testSubject.IsAccepted(project);
 
             // Verify
-            Assert.IsFalse(result, "Project with SonarExcludeProperty=false should NOT be accepted");
+            Assert.IsTrue(result, "Project with missing property SonarQubeExclude should be accepted");
 
-            // Test case 2: property false -> is accepted
+            // Test case 2: property non-bool -> is accepted
+            // Setup
+            project.SetBuildProperty(Constants.SonarQubeExcludeBuildPropertyKey, string.Empty);
+
+            // Act
+            result = testSubject.IsAccepted(project);
+
+            // Verify
+            Assert.IsTrue(result, "Project with non-bool property SonarQubeExclude should be accepted");
+
+            // Test case 3: property true -> not accepted
+            // Setup
+            project.SetBuildProperty(Constants.SonarQubeExcludeBuildPropertyKey, "true");
+            
+            // Act
+            result = testSubject.IsAccepted(project);
+
+            // Verify
+            Assert.IsFalse(result, "Project with property SonarQubeExclude=false should NOT be accepted");
+
+            // Test case 4: property false -> is accepted
             // Setup
             project.SetBuildProperty(Constants.SonarQubeExcludeBuildPropertyKey, "false");
 
@@ -72,7 +99,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             result = testSubject.IsAccepted(project);
 
             // Verify
-            Assert.IsTrue(result, "Project with SonarExcludeProperty=true should be accepted");
+            Assert.IsTrue(result, "Project with property SonarQubeExclude=true should be accepted");
         }
 
         [TestMethod]
@@ -84,17 +111,34 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             var project = new ProjectMock("supported.csproj");
             project.SetCSProjectKind();
 
-            // Test case 1: property true -> not accepted
-            // Setup
-            project.SetBuildProperty(Constants.SonarQubeTestProjectBuildPropertyKey, "true");
-
+            // Test case 1: missing property -> accepted
             // Act
             var result = testSubject.IsAccepted(project);
 
             // Verify
-            Assert.IsFalse(result, "Project with SonarQubeTestProject=false should NOT be accepted");
+            Assert.IsTrue(result, "Project with missing property SonarQubeTestProject should be accepted");
 
-            // Test case 2: property false -> is accepted
+            // Test case 2: non-bool property -> accepted
+            // Setup
+            project.SetBuildProperty(Constants.SonarQubeTestProjectBuildPropertyKey, string.Empty);
+
+            // Act
+            result = testSubject.IsAccepted(project);
+
+            // Verify
+            Assert.IsTrue(result, "Project with non-bool property SonarQubeTestProject should be accepted");
+
+            // Test case 3: property true -> not accepted
+            // Setup
+            project.SetBuildProperty(Constants.SonarQubeTestProjectBuildPropertyKey, "true");
+
+            // Act
+            result = testSubject.IsAccepted(project);
+
+            // Verify
+            Assert.IsFalse(result, "Project with property SonarQubeTestProject=false should NOT be accepted");
+
+            // Test case 4: property false -> is accepted
             // Setup
             project.SetBuildProperty(Constants.SonarQubeTestProjectBuildPropertyKey, "false");
 
@@ -102,7 +146,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             result = testSubject.IsAccepted(project);
 
             // Verify
-            Assert.IsTrue(result, "Project with SonarQubeTestProject=true should be accepted");
+            Assert.IsTrue(result, "Project with property SonarQubeTestProject=true should be accepted");
         }
 
         [TestMethod]
@@ -127,7 +171,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         {
             // Setup
             var testSubject = this.CreateTestSubject();
-            testSubject.SetTestRegex(new Regex(".*barfoo.*"));
+            testSubject.SetTestRegex(new Regex(".*barfoo.*", RegexOptions.None, TimeSpan.FromSeconds(1)));
 
             var project = new ProjectMock("foobarfoobar.csproj");
             project.SetCSProjectKind();
@@ -144,7 +188,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         {
             // Setup
             var testSubject = this.CreateTestSubject();
-            testSubject.SetTestRegex(new Regex(".*notfound.*"));
+            testSubject.SetTestRegex(new Regex(".*notfound.*", RegexOptions.None, TimeSpan.FromSeconds(1)));
 
             var project = new ProjectMock("foobarfoobar.csproj");
             project.SetCSProjectKind();

--- a/src/Integration.UnitTests/Binding/ProjectSystemFilterTests.cs
+++ b/src/Integration.UnitTests/Binding/ProjectSystemFilterTests.cs
@@ -1,0 +1,171 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ProjectSystemFilterTests.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarLint.VisualStudio.Integration.Binding;
+using System;
+using System.Text.RegularExpressions;
+using System.Windows.Threading;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
+{
+    [TestClass]
+    public class ProjectSystemFilterTests
+    {
+        private ConfigurableServiceProvider serviceProvider;
+        private ConfigurableVsProjectSystemHelper projectSystem;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            this.serviceProvider = new ConfigurableServiceProvider();
+            this.projectSystem = new ConfigurableVsProjectSystemHelper(this.serviceProvider);
+            this.serviceProvider.RegisterService(typeof(IProjectSystemHelper), this.projectSystem);
+        }
+
+        #region Tests 
+
+        [TestMethod]
+        public void ProjectSystemFilter_IsAccepted_UnsupportedLanguage_IsFalse()
+        {
+            // Setup
+            var testSubject = this.CreateTestSubject();
+
+            var project = new ProjectMock("unsupported.vbproj");
+            project.SetVBProjectKind();
+
+            // Act
+            var result = testSubject.IsAccepted(project);
+
+            // Verify
+            Assert.IsFalse(result, "Project of unsupported language type should not be accepted");
+        }
+
+        [TestMethod]
+        public void ProjectSystemFilter_IsAccepted_SonarExcludeProperty_ReturnsPropertyValue()
+        {
+            // Setup
+            var testSubject = this.CreateTestSubject();
+
+            var project = new ProjectMock("supported.csproj");
+            project.SetCSProjectKind();
+
+            // Test case 1: property true -> not accepted
+            // Setup
+            project.SetBuildProperty(Constants.SonarQubeExcludeBuildPropertyKey, "true");
+            
+            // Act
+            var result = testSubject.IsAccepted(project);
+
+            // Verify
+            Assert.IsFalse(result, "Project with SonarExcludeProperty=false should NOT be accepted");
+
+            // Test case 2: property false -> is accepted
+            // Setup
+            project.SetBuildProperty(Constants.SonarQubeExcludeBuildPropertyKey, "false");
+
+            // Act
+            result = testSubject.IsAccepted(project);
+
+            // Verify
+            Assert.IsTrue(result, "Project with SonarExcludeProperty=true should be accepted");
+        }
+
+        [TestMethod]
+        public void ProjectSystemFilter_IsAccepted_SonarTestProjectProperty_ReturnsPropertyValue()
+        {
+            // Setup
+            var testSubject = this.CreateTestSubject();
+
+            var project = new ProjectMock("supported.csproj");
+            project.SetCSProjectKind();
+
+            // Test case 1: property true -> not accepted
+            // Setup
+            project.SetBuildProperty(Constants.SonarQubeTestProjectBuildPropertyKey, "true");
+
+            // Act
+            var result = testSubject.IsAccepted(project);
+
+            // Verify
+            Assert.IsFalse(result, "Project with SonarQubeTestProject=false should NOT be accepted");
+
+            // Test case 2: property false -> is accepted
+            // Setup
+            project.SetBuildProperty(Constants.SonarQubeTestProjectBuildPropertyKey, "false");
+
+            // Act
+            result = testSubject.IsAccepted(project);
+
+            // Verify
+            Assert.IsTrue(result, "Project with SonarQubeTestProject=true should be accepted");
+        }
+
+        [TestMethod]
+        public void ProjectSystemFilter_IsAccepted_IsKnownTestProject_ReturnsFalse()
+        {
+            // Setup
+            var testSubject = this.CreateTestSubject();
+
+            var project = new ProjectMock("knownproject.csproj");
+            project.SetCSProjectKind();
+            project.SetTestProject();
+
+            // Act
+            var result = testSubject.IsAccepted(project);
+
+            // Verify
+            Assert.IsFalse(result, "Project of known test project type should NOT be accepted");
+        }
+
+        [TestMethod]
+        public void ProjectSystemFilter_IsAccepted_MatchesTestRegex_ReturnsFalse()
+        {
+            // Setup
+            var testSubject = this.CreateTestSubject();
+            testSubject.SetTestRegex(new Regex(".*barfoo.*"));
+
+            var project = new ProjectMock("foobarfoobar.csproj");
+            project.SetCSProjectKind();
+
+            // Act
+            var result = testSubject.IsAccepted(project);
+
+            // Verify
+            Assert.IsFalse(result, "Project with name that matches test regex should NOT be accepted");
+        }
+
+        [TestMethod]
+        public void ProjectSystemFilter_IsAccepted_DoesNotMatchTestRegex_ReturnsTrue()
+        {
+            // Setup
+            var testSubject = this.CreateTestSubject();
+            testSubject.SetTestRegex(new Regex(".*notfound.*"));
+
+            var project = new ProjectMock("foobarfoobar.csproj");
+            project.SetCSProjectKind();
+
+            // Act
+            var result = testSubject.IsAccepted(project);
+
+            // Verify
+            Assert.IsTrue(result, "Project with name that does not match test regex should be accepted");
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private ProjectSystemFilter CreateTestSubject()
+        {
+            var host = new ConfigurableHost(this.serviceProvider, Dispatcher.CurrentDispatcher);
+            return new ProjectSystemFilter(host);
+        }
+
+        #endregion
+    }
+}

--- a/src/Integration.UnitTests/Integration.UnitTests.csproj
+++ b/src/Integration.UnitTests/Integration.UnitTests.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Persistence\SolutionBindingTests.cs" />
     <Compile Include="Progress\ProgressNotificationListenerTests.cs" />
     <Compile Include="Progress\ProgressStepRunnerTests.cs" />
+    <Compile Include="Binding\ProjectSystemFilterTests.cs" />
     <Compile Include="RuleSetHelperTests.cs" />
     <Compile Include="SanityTests.cs" />
     <Compile Include="Connection\ConnectionWorkflowTests.cs" />

--- a/src/Integration.UnitTests/Integration.UnitTests.csproj
+++ b/src/Integration.UnitTests/Integration.UnitTests.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Connection\ConnectionInformationDialogTests.cs" />
     <Compile Include="Framework\ConfigurableCredentialStore.cs" />
     <Compile Include="IServiceProviderExtensionsTests.cs" />
+    <Compile Include="LanguageTests.cs" />
     <Compile Include="LocalServices\RuleSetInspectorTests.cs" />
     <Compile Include="LocalServices\SolutionRuleSetsInformationProviderTests.cs" />
     <Compile Include="LocalServices\SourceControlledFileSystemTests.cs" />

--- a/src/Integration.UnitTests/LanguageTests.cs
+++ b/src/Integration.UnitTests/LanguageTests.cs
@@ -1,0 +1,107 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests
+{
+    [TestClass]
+    public class LanguageTests
+    {
+        [TestMethod]
+        public void Language_Ctor_ArgChecks()
+        {
+            // Setup
+            var key = "k";
+            var name = "MyName";
+            var guid = Guid.NewGuid().ToString("N");
+
+            // Act + Verify
+            // Nulls
+            Exceptions.Expect<ArgumentNullException>(() => new Language(null, name, guid));
+            Exceptions.Expect<ArgumentNullException>(() => new Language(key, null, guid));
+            Exceptions.Expect<ArgumentNullException>(() => new Language(key, name, null));
+
+            // Bad GUID
+            Exceptions.Expect<FormatException>(() => new Language(key, name, "thisisnotaguid"));
+        }
+
+        [TestMethod]
+        public void Language_IsSupported_SupportedLanguage_IsTrue()
+        {
+            // Act + Verify
+            foreach(var supportedLang in Language.SupportedLanguages)
+            {
+                Assert.IsTrue(supportedLang.IsSupported, "Supported langugage should be supported");
+            }
+        }
+
+        [TestMethod]
+        public void Language_IsSupported_UnsupportedLanguage_IsFalse()
+        {
+            // Setup
+            var unsupportedLangs = Language.KnownLanguages.Except(Language.SupportedLanguages);
+
+            // Sanity
+            Debug.Assert(unsupportedLangs.Any(), "No known but unsupported languages");
+
+            // Act + Verify
+            foreach (var unsupportedLang in unsupportedLangs)
+            {
+                Assert.IsFalse(unsupportedLang.IsSupported, "Unsupported langugage should NOT be supported");
+            }
+        }
+
+        [TestMethod]
+        public void Language_ForProject_KnownLanguage_ReturnsCorrectLanguage()
+        {
+            // Test case 1: Unknown
+            // Setup
+            var otherProject = new ProjectMock("other.proj");
+
+            // Act
+            var otherProjectLanguage = Language.ForProject(otherProject);
+
+            // Verify
+            Assert.IsNull(otherProjectLanguage, "Expected Language to be null for unknown project");
+
+            // Test case 2: C#
+            // Setup
+            var csProject = new ProjectMock("cs1.csproj");
+            csProject.SetCSProjectKind();
+
+            // Act
+            var csProjectLanguage = Language.ForProject(csProject);
+
+            // Verify
+            Assert.AreEqual(Language.CSharp, csProjectLanguage, "Unexpected Language for C# project");
+
+            // Test case 3: VB
+            // Setup
+            var vbNetProject = new ProjectMock("vb1.vbproj");
+            vbNetProject.SetVBProjectKind();
+
+            // Act
+            var vbNetProjectLanguage = Language.ForProject(vbNetProject);
+
+            // Verify
+            Assert.AreEqual(Language.VBNET, vbNetProjectLanguage, "Unexpected Language for C# project");
+        }
+
+        [TestMethod]
+        public void Language_Equality()
+        {
+            // Setup
+            var lang1a = new Language("lang1", "Language 1", "{4FE75C7D-F43F-4A72-940C-47C97710BCCA}");
+            var lang1b = new Language("lang1", "Language 1", "{4FE75C7D-F43F-4A72-940C-47C97710BCCA}");
+            var lang2 = new Language("lang2", "Language 2", "{7A128822-05AA-49D0-A3C7-16F03F3A92E5}");
+
+            // Act + Verify
+            Assert.AreEqual(lang1a, lang1b, "Languages with the same keys and GUIDs should be equal");
+            Assert.AreNotEqual(lang1a, lang2, "Languages with different keys and GUIDs should NOT be equal");
+        }
+    }
+}

--- a/src/Integration/Binding/BindingController.cs
+++ b/src/Integration/Binding/BindingController.cs
@@ -102,7 +102,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
                 && !this.host.VisualStateManager.IsBusy
                 && VsShellUtils.IsSolutionExistsAndFullyLoaded()
                 && VsShellUtils.IsSolutionExistsAndNotBuildingAndNotDebugging()
-                && (this.projectSystemHelper.GetSolutionManagedProjects()?.Any() ?? false);
+                && (this.projectSystemHelper.GetSolutionProjects()?.Any() ?? false);
         }
 
         private void OnBind(ProjectInformation projectInformation)

--- a/src/Integration/Binding/BindingWorkflow.cs
+++ b/src/Integration/Binding/BindingWorkflow.cs
@@ -5,11 +5,12 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using EnvDTE;
 using Microsoft.VisualStudio.CodeAnalysis.RuleSets;
+using Microsoft.VisualStudio.Shell;
 using SonarLint.VisualStudio.Integration.Progress;
 using SonarLint.VisualStudio.Integration.Resources;
 using SonarLint.VisualStudio.Integration.Service;
-using SonarLint.VisualStudio.Integration.TeamExplorer;
 using SonarLint.VisualStudio.Progress.Controller;
 using System;
 using System.Collections.Generic;
@@ -17,6 +18,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 
 namespace SonarLint.VisualStudio.Integration.Binding
@@ -28,16 +30,22 @@ namespace SonarLint.VisualStudio.Integration.Binding
     {
         private readonly IHost host;
         private readonly ProjectInformation project;
-        private readonly IProjectSystemHelper projectSystemHelper;
+        private readonly IProjectSystemHelper projectSystem;
+        private readonly IProjectSystemFilter projectFilter;
         private readonly SolutionBindingOperation solutionBindingOperation;
 
-        internal readonly Dictionary<string, RuleSetGroup> LanguageToGroupMapping = new Dictionary<string, RuleSetGroup>
+        internal readonly Dictionary<Language, RuleSetGroup> LanguageToGroupMapping = new Dictionary<Language, RuleSetGroup>
         {
-            {SonarQubeServiceWrapper.CSharpLanguage, RuleSetGroup.CSharp },
-            {SonarQubeServiceWrapper.VBLanguage, RuleSetGroup.VB }
+            {Language.CSharp, RuleSetGroup.CSharp },
+            {Language.VBNET, RuleSetGroup.VB }
         };        
 
         public BindingWorkflow(IHost host, ProjectInformation project)
+            : this(host, project, null)
+        {
+        }
+
+        internal /*for testing purposes*/ BindingWorkflow(IHost host, ProjectInformation project, IProjectSystemFilter projectFilter)
         {
             if (host == null)
             {
@@ -51,8 +59,10 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
             this.host = host;
             this.project = project;
-            this.projectSystemHelper = this.host.GetService<IProjectSystemHelper>();
-            this.projectSystemHelper.AssertLocalServiceIsNotNull();
+            this.projectSystem = this.host.GetService<IProjectSystemHelper>();
+            this.projectSystem.AssertLocalServiceIsNotNull();
+
+            this.projectFilter = projectFilter ?? new ProjectSystemFilter(this.host);
 
             this.solutionBindingOperation = new SolutionBindingOperation(
                     this.host,
@@ -61,6 +71,11 @@ namespace SonarLint.VisualStudio.Integration.Binding
         }
 
         #region Workflow state
+
+        public List<Project> BindingProjects
+        {
+            get;
+        } = new List<Project>();
 
         public Dictionary<RuleSetGroup, RuleSet> Rulesets
         {
@@ -89,23 +104,12 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
         public IProgressEvents Run()
         {
-            List<string> languages = new List<string>();
-            if (this.projectSystemHelper.GetSolutionManagedProjects().Any(p => ProjectSystemHelper.IsCSharpProject(p)))
-            {
-                languages.Add(SonarQubeServiceWrapper.CSharpLanguage);
-            }
-
-            if (this.projectSystemHelper.GetSolutionManagedProjects().Any(p => ProjectSystemHelper.IsVBProject(p)))
-            {
-                languages.Add(SonarQubeServiceWrapper.VBLanguage);
-            }
-
-            Debug.Assert(languages.Count > 0, "Expecting managed projects in solution");
             Debug.Assert(this.host.ActiveSection != null, "Expect the section to be attached at least until this method returns");
+            Debug.Assert(this.projectSystem.GetSolutionProjects().Any(), "Expecting projects in solution");
 
             IProgressEvents progress = ProgressStepRunner.StartAsync(this.host,
                 this.host.ActiveSection.ProgressHost,
-                (controller) => this.CreateWorkflowSteps(controller, languages));
+                controller => this.CreateWorkflowSteps(controller));
 
             this.DebugOnly_MonitorProgress(progress);
 
@@ -118,7 +122,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
             progress.RunOnFinished(r => VsShellUtils.WriteToGeneralOutputPane(this.host, "DEBUGONLY: Binding workflow finished, Execution result: {0}", r));
         }
 
-        private ProgressStepDefinition[] CreateWorkflowSteps(IProgressController controller, IEnumerable<string> languages)
+        private ProgressStepDefinition[] CreateWorkflowSteps(IProgressController controller)
         {
             StepAttributes IndeterminateNonCancellableUIStep = StepAttributes.Indeterminate | StepAttributes.NonCancellable;
             StepAttributes HiddenIndeterminateNonImpactingNonCancellableUIStep = IndeterminateNonCancellableUIStep | StepAttributes.Hidden | StepAttributes.NoProgressImpact;
@@ -133,7 +137,13 @@ namespace SonarLint.VisualStudio.Integration.Binding
                         (token, notifications) => this.PromptSaveSolutionIfDirty(controller, token)),
 
                 new ProgressStepDefinition(Strings.BindingProjectsDisplayMessage, StepAttributes.BackgroundThread,
-                        (token, notifications) => this.DownloadQualityProfile(controller, token, notifications, languages)),
+                        (token, notifications) => this.DownloadBindingParameters(controller, token, notifications)),
+
+                new ProgressStepDefinition(Strings.BindingProjectsDisplayMessage, StepAttributes.Indeterminate,
+                        (token, notifications) => this.DiscoverProjects(controller, notifications)),
+
+                new ProgressStepDefinition(Strings.BindingProjectsDisplayMessage, StepAttributes.BackgroundThread,
+                        (token, notifications) => this.DownloadQualityProfile(controller, token, notifications, this.GetBindingLanguages())),
 
                 new ProgressStepDefinition(null, HiddenIndeterminateNonImpactingNonCancellableUIStep,
                         (token, notifications) => { NuGetHelper.LoadService(this.host); /*The service needs to be loaded on UI thread*/ }),
@@ -157,9 +167,11 @@ namespace SonarLint.VisualStudio.Integration.Binding
                         (token, notifications) => this.EmitBindingCompleteMessage(notifications))
             };
         }
+
         #endregion
 
         #region Workflow steps
+
         internal /*for testing purposes*/ void PromptSaveSolutionIfDirty(IProgressController controller, CancellationToken token)
         {
             if (!VsShellUtils.SaveSolution(this.host, silent: false))
@@ -170,26 +182,55 @@ namespace SonarLint.VisualStudio.Integration.Binding
             }
         }
 
-        internal /*for testing purposes*/ void SilentSaveSolutionIfDirty()
+        internal /*for testing purposes*/ void DownloadBindingParameters(IProgressController controller, CancellationToken token, IProgressStepExecutionEvents notifications)
         {
-            bool saved = VsShellUtils.SaveSolution(this.host, silent: true);
-            Debug.Assert(saved, "Should not be cancellable");
+            notifications.ProgressChanged(Strings.PreparingBindingWorkflowProgessMessage, double.NaN);
+
+            var properties = this.host.SonarQubeService.GetProperties(token);
+
+            if (token.IsCancellationRequested)
+            {
+                AbortWorkflow(controller, token);
+                return;
+            }
+
+            var testProjRegexProperty = properties.FirstOrDefault(x => StringComparer.Ordinal.Equals(x.Key, ServerProperty.TestProjectRegexKey));
+            var testProjRegexPattern = testProjRegexProperty?.Value ?? ServerProperty.TestProjectRegexDefaultValue;
+
+            this.projectFilter.SetTestRegex(new Regex(testProjRegexPattern, RegexOptions.IgnoreCase));
         }
 
-        internal /*for testing purposes*/ void DownloadQualityProfile(IProgressController controller, CancellationToken cancellationToken, IProgressStepExecutionEvents notificationEvents, IEnumerable<string> languages)
+        internal /*for testing purposes*/ void DiscoverProjects(IProgressController controller, IProgressStepExecutionEvents notifications)
+        {
+            Debug.Assert(ThreadHelper.CheckAccess(), "Expected step to be run on the UI thread");
+
+            notifications.ProgressChanged(Strings.DiscoveringSolutionProjectsProgressMessage, double.NaN);
+
+            this.BindingProjects.AddRange(this.projectSystem
+                                              .GetSolutionProjects()
+                                              .Where(x => this.projectFilter.IsAccepted(x)));
+            
+            if (!this.BindingProjects.Any())
+            {
+                VsShellUtils.WriteToGeneralOutputPane(this.host, Strings.NoProjectsApplicableForBinding);
+                AbortWorkflow(controller, CancellationToken.None);
+            }
+        }
+
+        internal /*for testing purposes*/ void DownloadQualityProfile(IProgressController controller, CancellationToken cancellationToken, IProgressStepExecutionEvents notificationEvents, IEnumerable<Language> languages)
         {
             Debug.Assert(controller != null);
             Debug.Assert(notificationEvents != null);
 
             bool failed = false;
-            Dictionary<string, RuleSet> rulesets = new Dictionary<string, RuleSet>();
+            var rulesets = new Dictionary<Language, RuleSet>();
             DeterminateStepProgressNotifier notifier = new DeterminateStepProgressNotifier(notificationEvents, languages.Count());
 
             foreach (var language in languages)
             {
-                notifier.NotifyCurrentProgress(string.Format(CultureInfo.CurrentCulture, Strings.DownloadingQualityProfileProgressMessage, language));
+                notifier.NotifyCurrentProgress(string.Format(CultureInfo.CurrentCulture, Strings.DownloadingQualityProfileProgressMessage, language.Name));
 
-                var export = this.host.SonarQubeService.GetExportProfile(this.project, language, cancellationToken);
+                var export = this.host.SonarQubeService.GetExportProfile(this.project, language.ServerKey, cancellationToken);
 
                 if (export == null)
                 {
@@ -236,7 +277,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
             notificationEvents.ProgressChanged(Strings.RuleSetGenerationProgressMessage, double.NaN);
 
             this.solutionBindingOperation.RegisterKnownRuleSets(this.Rulesets);
-            this.solutionBindingOperation.Initialize();
+            this.solutionBindingOperation.Initialize(this.BindingProjects);
         }
 
         private void PrepareSolutionBinding(CancellationToken token)
@@ -252,7 +293,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
             {
                 AbortWorkflow(controller, token);
                 return;
-        }
+            }
         }
 
         /// <summary>
@@ -269,15 +310,14 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
             Debug.Assert(this.NuGetPackages.Count == this.NuGetPackages.Distinct().Count(), "Duplicate NuGet packages specified");
 
-            var managedProjects = this.projectSystemHelper.GetSolutionManagedProjects().ToArray();
-            if (!managedProjects.Any())
+            if (!this.BindingProjects.Any())
             {
-                Debug.Fail("Not expected to be called when there are no managed projects");
+                Debug.Fail("Not expected to be called when there are no projects");
                 return;
             }
 
-            DeterminateStepProgressNotifier progressNotifier = new DeterminateStepProgressNotifier(notificationEvents, managedProjects.Length * this.NuGetPackages.Count);
-            foreach (var project in managedProjects)
+            DeterminateStepProgressNotifier progressNotifier = new DeterminateStepProgressNotifier(notificationEvents, this.BindingProjects.Count * this.NuGetPackages.Count);
+            foreach (var project in this.BindingProjects)
             {
                 foreach (var packageInfo in this.NuGetPackages)
                 {
@@ -297,6 +337,12 @@ namespace SonarLint.VisualStudio.Integration.Binding
             }
         }
 
+        internal /*for testing purposes*/ void SilentSaveSolutionIfDirty()
+        {
+            bool saved = VsShellUtils.SaveSolution(this.host, silent: true);
+            Debug.Assert(saved, "Should not be cancellable");
+        }
+
         internal /*for testing purposes*/ void EmitBindingCompleteMessage(IProgressStepExecutionEvents notifications)
             {
             var message = this.AllNuGetPackagesInstalled
@@ -304,10 +350,12 @@ namespace SonarLint.VisualStudio.Integration.Binding
                 : Strings.FinishedSolutionBindingWorkflowNotAllPackagesInstalled;
             notifications.ProgressChanged(message, double.NaN);
         }
+
         #endregion
 
         #region Helpers
-        private RuleSetGroup LanguageToGroup(string language)
+
+        private RuleSetGroup LanguageToGroup(Language language)
         {
             RuleSetGroup group;
             if (!this.LanguageToGroupMapping.TryGetValue(language, out group))
@@ -323,6 +371,12 @@ namespace SonarLint.VisualStudio.Integration.Binding
             bool aborted = controller.TryAbort();
             Debug.Assert(aborted || token.IsCancellationRequested, "Failed to abort the workflow");
         }
+
+        internal /*testing purposes*/ IEnumerable<Language> GetBindingLanguages()
+        {
+            return this.BindingProjects.Select(Language.ForProject).Distinct();
+        }
+
         #endregion
 
     }

--- a/src/Integration/Binding/IProjectSystemFilter.cs
+++ b/src/Integration/Binding/IProjectSystemFilter.cs
@@ -1,0 +1,24 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="IProjectSystemFilter.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Text.RegularExpressions;
+
+namespace SonarLint.VisualStudio.Integration.Binding
+{
+    internal interface IProjectSystemFilter
+    {
+        /// <summary>
+        /// Returns true if the given project passed the filter criteria. False otherwise.
+        /// </summary>
+        bool IsAccepted(EnvDTE.Project project);
+
+        /// <summary>
+        /// Set regular expression to be used to identify a test project.
+        /// </summary>
+        void SetTestRegex(Regex regex);
+    }
+}

--- a/src/Integration/Binding/ProjectSystemFilter.cs
+++ b/src/Integration/Binding/ProjectSystemFilter.cs
@@ -1,0 +1,106 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ProjectSystemFilter.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Microsoft.VisualStudio;
+using Microsoft.VisualStudio.Shell.Interop;
+using System;
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using DteProject = EnvDTE.Project;
+
+namespace SonarLint.VisualStudio.Integration.Binding
+{
+    internal class ProjectSystemFilter : IProjectSystemFilter
+    {
+        private readonly IProjectSystemHelper projectSystem;
+
+        private Regex testRegex;
+
+        public ProjectSystemFilter(IHost host)
+        {
+            if (host == null)
+            {
+                throw new ArgumentNullException(nameof(host));
+            }
+
+            this.projectSystem = host.GetService<IProjectSystemHelper>();
+            this.projectSystem.AssertLocalServiceIsNotNull();
+        }
+
+        #region IProjectSystemFilter
+
+        public bool IsAccepted(DteProject dteProject)
+        {
+            var projectName = dteProject.Name;
+            var hierarchy = this.projectSystem.GetIVsHierarchy(dteProject);
+            var propertyStorage = hierarchy as IVsBuildPropertyStorage;
+
+            Debug.Assert(hierarchy != null, $"Couldn't get IVsHierarchy for DTE project '{projectName}'");
+            Debug.Assert(propertyStorage != null, $"Couldn't get IVsBuildPropertyStorage for the IVsHierarchy '{projectName}'");
+
+            // Accept only supported languages
+            var language = Language.ForProject(dteProject);
+            if (language == null || !language.IsSupported)
+            {
+                return false;
+            }
+
+            // General exclusions
+            // If exclusion property is set, this takes precedence
+            bool? sonarExclude = GetPropertyBool(propertyStorage, "SonarQubeExclude");
+            if (sonarExclude.HasValue)
+            {
+                return !sonarExclude.Value;
+            }
+
+            // Ignore test projects
+            // If specifically marked with test project property, use that to specifiy if test project or not
+            bool? sonarTest = GetPropertyBool(propertyStorage, "SonarQubeTestProject");
+            if (sonarTest.HasValue)
+            {
+                return !sonarTest.Value;
+            }
+            // Otherwise, try to detect test project using known project types and/or regex match
+            else if (ProjectSystemHelper.IsKnownTestProject(hierarchy)
+                 || (this.testRegex != null && this.testRegex.IsMatch(projectName)))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public void SetTestRegex(Regex regex)
+        {
+            this.testRegex = regex;
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private static bool? GetPropertyBool(IVsBuildPropertyStorage propertyStorage, string propertyName)
+        {
+            string valueString = null;
+            var hr = propertyStorage.GetPropertyValue(propertyName, string.Empty,
+                (uint)_PersistStorageType.PST_PROJECT_FILE, out valueString);
+
+            if (ErrorHandler.Succeeded(hr))
+            {
+                bool value;
+                if (bool.TryParse(valueString, out value))
+                {
+                    return value;
+                }
+            }
+
+            return null;
+        }
+
+        #endregion
+    }
+}

--- a/src/Integration/Binding/ProjectSystemFilter.cs
+++ b/src/Integration/Binding/ProjectSystemFilter.cs
@@ -51,7 +51,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
             // General exclusions
             // If exclusion property is set, this takes precedence
-            bool? sonarExclude = GetPropertyBool(propertyStorage, "SonarQubeExclude");
+            bool? sonarExclude = GetPropertyBool(propertyStorage, Constants.SonarQubeExcludeBuildPropertyKey);
             if (sonarExclude.HasValue)
             {
                 return !sonarExclude.Value;
@@ -59,7 +59,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
             // Ignore test projects
             // If specifically marked with test project property, use that to specifiy if test project or not
-            bool? sonarTest = GetPropertyBool(propertyStorage, "SonarQubeTestProject");
+            bool? sonarTest = GetPropertyBool(propertyStorage, Constants.SonarQubeTestProjectBuildPropertyKey);
             if (sonarTest.HasValue)
             {
                 return !sonarTest.Value;

--- a/src/Integration/Binding/SolutionBindingOperation.cs
+++ b/src/Integration/Binding/SolutionBindingOperation.cs
@@ -25,7 +25,6 @@ namespace SonarLint.VisualStudio.Integration.Binding
         private readonly IServiceProvider serviceProvider;
         private readonly ISourceControlledFileSystem sourceControlledFileSystem;
         private readonly IProjectSystemHelper projectSystem;
-
         private readonly List<IBindingOperation> childBinder = new List<IBindingOperation>();
         private readonly Dictionary<RuleSetGroup, RuleSetInformation> ruleSetsInformationMap = new Dictionary<RuleSetGroup, RuleSetInformation>();
         private readonly ConnectionInformation connection;
@@ -38,7 +37,6 @@ namespace SonarLint.VisualStudio.Integration.Binding
                 throw new ArgumentNullException(nameof(serviceProvider));
             }
 
-          
             if (connection == null)
             {
                 throw new ArgumentNullException(nameof(connection));
@@ -116,11 +114,16 @@ namespace SonarLint.VisualStudio.Integration.Binding
         #endregion
 
         #region Public API
-        public void Initialize()
+        public void Initialize(IEnumerable<Project> projects)
         {
+            if (projects == null)
+            {
+                throw new ArgumentNullException(nameof(projects));
+            }
+
             this.SolutionFullPath = this.projectSystem.GetCurrentActiveSolution().FullName;
 
-            foreach (Project project in this.projectSystem.GetSolutionManagedProjects())
+            foreach (Project project in projects)
             {
                 var binder = new ProjectBindingOperation(serviceProvider, project, this);
                 binder.Initialize();

--- a/src/Integration/Constants.cs
+++ b/src/Integration/Constants.cs
@@ -54,5 +54,15 @@ namespace SonarLint.VisualStudio.Integration
         /// </summary>
         public const string RuleSetFileExtension = "ruleset";
 
+        /// <summary>
+        /// The build property key which corresponds to the explicit SonarQube project exclusion.
+        /// </summary>
+        public const string SonarQubeExcludeBuildPropertyKey = "SonarQubeExclude";
+
+        /// <summary>
+        /// The build property key which corresponds to the explicit SonarQube test project identification.
+        /// </summary>
+        public const string SonarQubeTestProjectBuildPropertyKey = "SonarQubeTestProject";
+
     }
 }

--- a/src/Integration/IProjectSystemHelper.cs
+++ b/src/Integration/IProjectSystemHelper.cs
@@ -7,6 +7,7 @@
 
 using EnvDTE;
 using EnvDTE80;
+using Microsoft.VisualStudio.Shell.Interop;
 using System;
 using System.Collections.Generic;
 
@@ -27,6 +28,8 @@ namespace SonarLint.VisualStudio.Integration
 
         void AddFileToProject(Project project, string file, string itemType);
 
-        IEnumerable<Project> GetSolutionManagedProjects();
+        IEnumerable<Project> GetSolutionProjects();
+
+        IVsHierarchy GetIVsHierarchy(Project dteProject);
     }
 }

--- a/src/Integration/Integration.csproj
+++ b/src/Integration/Integration.csproj
@@ -130,6 +130,7 @@
     <Compile Include="IHost.cs" />
     <Compile Include="IProjectSystemHelper.cs" />
     <Compile Include="IActiveSolutionTracker.cs" />
+    <Compile Include="Binding\IProjectSystemFilter.cs" />
     <Compile Include="IServiceProviderExtensions.cs" />
     <Compile Include="IIntegrationSettings.cs" />
     <Compile Include="IWebBrowser.cs" />
@@ -144,7 +145,10 @@
     <Compile Include="Persistence\ISolutionBinding.cs" />
     <Compile Include="Progress\IProgressStepRunnerWrapper.cs" />
     <Compile Include="RuleSetHelper.cs" />
+    <Compile Include="Language.cs" />
+    <Compile Include="Binding\ProjectSystemFilter.cs" />
     <Compile Include="Service\DataModel\ServerPlugin.cs" />
+    <Compile Include="Service\DataModel\ServerProperty.cs" />
     <Compile Include="Service\RoslynExporter\AdditionalFile.cs" />
     <Compile Include="Service\RoslynExporter\Configuration.cs" />
     <Compile Include="Service\RoslynExporter\Deployment.cs" />

--- a/src/Integration/Language.cs
+++ b/src/Integration/Language.cs
@@ -1,0 +1,107 @@
+﻿using SonarLint.VisualStudio.Integration.Resources;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace SonarLint.VisualStudio.Integration
+{
+    [DebuggerDisplay("{Name} (ServerKey: {ServerKey}, ProjectType: {ProjectType}, IsSupported: {IsSupported})")]
+    public sealed class Language : IEquatable<Language>
+    {
+        public readonly static Language CSharp = new Language("cs", Strings.CSharpLanguageName, ProjectSystemHelper.CSharpProjectKind);
+        public readonly static Language VBNET = new Language("vbnet", Strings.VBNetLanguageName, ProjectSystemHelper.VbProjectKind);
+
+        public string ServerKey { get; }
+
+        public string Name { get; }
+
+        public Guid ProjectType { get; set; }
+
+        public bool IsSupported => SupportedLanguages.Contains(this);
+
+        public static IEnumerable<Language> SupportedLanguages
+        {
+            get
+            {
+                yield return CSharp;
+                // We don't support VB.NET as the corresponding VB SonarQube server plugin has been
+                // updated to support the connected experience.
+                // yield return VBNET;
+            }
+        }
+
+        public static IEnumerable<Language> KnownLanguages
+        {
+            get
+            {
+                yield return CSharp;
+                yield return VBNET;
+            }
+        }
+
+        public Language(string serverKey, string name, string projectTypeGuid)
+        {
+            if (string.IsNullOrWhiteSpace(serverKey))
+            {
+                throw new ArgumentNullException(nameof(serverKey));
+            }
+
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            if (string.IsNullOrWhiteSpace(projectTypeGuid))
+            {
+                throw new ArgumentNullException(nameof(projectTypeGuid));
+            }
+
+            this.ServerKey = serverKey;
+            this.Name = name;
+            this.ProjectType = new Guid(projectTypeGuid);
+        }
+
+        public static Language ForProject(EnvDTE.Project dteProject)
+        {
+            if (dteProject == null)
+            {
+                throw new ArgumentNullException(nameof(dteProject));
+            }
+
+            Guid projectKind;
+            if (!Guid.TryParse(dteProject.Kind, out projectKind))
+            {
+                return null;
+            }
+
+            return KnownLanguages.FirstOrDefault(x => x.ProjectType == projectKind);
+        }
+
+        #region IEquatable<Language> and Equals
+
+        public bool Equals(Language other)
+        {
+            if (ReferenceEquals(other, this))
+            {
+                return true;
+            }
+
+            return other != null
+                && other.ServerKey == this.ServerKey
+                && other.ProjectType == this.ProjectType;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as Language);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.ServerKey.GetHashCode();
+        }
+
+        #endregion
+    }
+}

--- a/src/Integration/Language.cs
+++ b/src/Integration/Language.cs
@@ -7,36 +7,53 @@ using System.Linq;
 namespace SonarLint.VisualStudio.Integration
 {
     [DebuggerDisplay("{Name} (ServerKey: {ServerKey}, ProjectType: {ProjectType}, IsSupported: {IsSupported})")]
-    public sealed class Language : IEquatable<Language>
+    internal sealed class Language : IEquatable<Language>
     {
         public readonly static Language CSharp = new Language("cs", Strings.CSharpLanguageName, ProjectSystemHelper.CSharpProjectKind);
         public readonly static Language VBNET = new Language("vbnet", Strings.VBNetLanguageName, ProjectSystemHelper.VbProjectKind);
 
+        /// <summary>
+        /// The SonarQube server key.
+        /// </summary>
         public string ServerKey { get; }
 
+        /// <summary>
+        /// The language display name.
+        /// </summary>
         public string Name { get; }
 
+        /// <summary>
+        /// The VS project GUID for this language.
+        /// </summary>
         public Guid ProjectType { get; set; }
 
+        /// <summary>
+        /// Returns whether or not this language is a supported project language for binding.
+        /// </summary>
         public bool IsSupported => SupportedLanguages.Contains(this);
 
+        /// <summary>
+        /// All languages which are supported for project binding.
+        /// </summary>
         public static IEnumerable<Language> SupportedLanguages
         {
             get
             {
-                yield return CSharp;
+                return new[] { CSharp };
                 // We don't support VB.NET as the corresponding VB SonarQube server plugin has been
                 // updated to support the connected experience.
-                // yield return VBNET;
+                //return new[] { CSharp, VBNET };
             }
         }
 
+        /// <summary>
+        /// All known languages.
+        /// </summary>
         public static IEnumerable<Language> KnownLanguages
         {
             get
             {
-                yield return CSharp;
-                yield return VBNET;
+                return new[] { CSharp, VBNET };
             }
         }
 

--- a/src/Integration/ProjectSystemHelper.cs
+++ b/src/Integration/ProjectSystemHelper.cs
@@ -14,7 +14,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using DteProject = EnvDTE.Project;
 
 namespace SonarLint.VisualStudio.Integration
 {
@@ -47,22 +46,22 @@ namespace SonarLint.VisualStudio.Integration
             get { return this.serviceProvider; }
         }
 
-        public IEnumerable<DteProject> GetSolutionProjects()
+        public IEnumerable<Project> GetSolutionProjects()
         {
             IVsSolution solution = this.serviceProvider.GetService<SVsSolution, IVsSolution>();
             Debug.Assert(solution != null, "Cannot find SVsSolution");
 
             foreach (var hierarchy in EnumerateProjects(solution))
             {
-                DteProject dteProject = GetDteProject(hierarchy);
-                if (dteProject != null && Language.ForProject(dteProject) != null)
+                Project Project = GetProject(hierarchy);
+                if (Project != null && Language.ForProject(Project) != null)
                 {
-                    yield return dteProject;
+                    yield return Project;
                 }
             }
         }
 
-        public static DteProject GetDteProject(IVsHierarchy hierarchy)
+        public static Project GetProject(IVsHierarchy hierarchy)
         {
             if (hierarchy == null)
             {
@@ -72,18 +71,18 @@ namespace SonarLint.VisualStudio.Integration
             object project = null;
             if (ErrorHandler.Succeeded(hierarchy.GetProperty(VSConstants.VSITEMID_ROOT, (int)__VSHPROPID.VSHPROPID_ExtObject, out project)))
             {
-                return project as DteProject;
+                return project as Project;
             }
             return null;
         }
 
-        public IVsHierarchy GetIVsHierarchy(DteProject dteProject)
+        public IVsHierarchy GetIVsHierarchy(Project Project)
         {
             IVsSolution solution = this.serviceProvider.GetService<SVsSolution, IVsSolution>();
             Debug.Assert(solution != null, "Cannot find SVsSolution");
 
             IVsHierarchy hierarchy;
-            if (ErrorHandler.Succeeded(solution.GetProjectOfUniqueName(dteProject.UniqueName, out hierarchy)))
+            if (ErrorHandler.Succeeded(solution.GetProjectOfUniqueName(Project.UniqueName, out hierarchy)))
             {
                 return hierarchy;
             }
@@ -91,7 +90,7 @@ namespace SonarLint.VisualStudio.Integration
             return null;
         }
 
-        public bool IsFileInProject(DteProject project, string file)
+        public bool IsFileInProject(Project project, string file)
         {
             if (project == null)
             {
@@ -121,7 +120,7 @@ namespace SonarLint.VisualStudio.Integration
             return false;
         }
 
-        public void AddFileToProject(DteProject project, string fullFilePath)
+        public void AddFileToProject(Project project, string fullFilePath)
         {
             if (project == null)
             {
@@ -139,7 +138,7 @@ namespace SonarLint.VisualStudio.Integration
             }
         }
 
-        public void AddFileToProject(DteProject project, string fullFilePath, string itemType)
+        public void AddFileToProject(Project project, string fullFilePath, string itemType)
         {
             if (project == null)
             {
@@ -179,17 +178,17 @@ namespace SonarLint.VisualStudio.Integration
             return solution;
         }
 
-        public DteProject GetSolutionItemsProject()
+        public Project GetSolutionItemsProject()
         {
             string solutionItemsFolderName = this.GetSolutionItemsFolderName();
 
             Solution2 solution = this.GetCurrentActiveSolution();
 
-            DteProject solutionItemsProject = null;
-            // Enumerating instead of using OfType<DteProject> due to a bug in
+            Project solutionItemsProject = null;
+            // Enumerating instead of using OfType<Project> due to a bug in
             // install shield projects that will throw an exception
 #pragma warning disable S3217
-            foreach (DteProject project in solution.Projects)
+            foreach (Project project in solution.Projects)
 #pragma warning restore S3217
             {
                 // Check if Solution Items folder already exists
@@ -265,22 +264,22 @@ namespace SonarLint.VisualStudio.Integration
             return GetAggregateProjectKinds(vsProject).Contains(TestProjectKindGuid);
         }
 
-        private static bool IsManagedProject(DteProject project)
+        private static bool IsManagedProject(Project project)
         {
             return IsCSharpProject(project) || IsVBProject(project);
         }
 
-        public static bool IsVBProject(DteProject project)
+        public static bool IsVBProject(Project project)
         {
             return IsProjectKind(project, VbProjectKind);
         }
 
-        public static bool IsCSharpProject(DteProject project)
+        public static bool IsCSharpProject(Project project)
         {
             return IsProjectKind(project, CSharpProjectKind);
         }
 
-        private static bool IsProjectKind(DteProject project, string projectKindGuidString)
+        private static bool IsProjectKind(Project project, string projectKindGuidString)
         {
             return StringComparer.OrdinalIgnoreCase.Equals(projectKindGuidString, project.Kind);
         }

--- a/src/Integration/Resources/Strings.Designer.cs
+++ b/src/Integration/Resources/Strings.Designer.cs
@@ -432,6 +432,15 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Test project regular expression pattern &apos;{0}&apos; is invalid. The default will be used instead. Please check your server settings..
+        /// </summary>
+        public static string InvalidTestProjectRegexPattern {
+            get {
+                return ResourceManager.GetString("InvalidTestProjectRegexPattern", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Could not acquire service: {0}.
         /// </summary>
         public static string MissingService {
@@ -500,6 +509,15 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         public static string ProductAuthors {
             get {
                 return ResourceManager.GetString("ProductAuthors", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not get the IVsHierarchy/IVsBuildPropertyStorage for the given project is IVsBuildPropertyStorage for the given EnvDTE.Project.
+        /// </summary>
+        public static string ProjectFilterDteProjectFailedToGetIVs {
+            get {
+                return ResourceManager.GetString("ProjectFilterDteProjectFailedToGetIVs", resourceCulture);
             }
         }
         

--- a/src/Integration/Resources/Strings.Designer.cs
+++ b/src/Integration/Resources/Strings.Designer.cs
@@ -251,6 +251,15 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to C#.
+        /// </summary>
+        public static string CSharpLanguageName {
+            get {
+                return ResourceManager.GetString("CSharpLanguageName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Disconnect.
         /// </summary>
         public static string DisconnectCommandDisplayText {
@@ -265,6 +274,15 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         public static string DisconnectCommandTooltip {
             get {
                 return ResourceManager.GetString("DisconnectCommandTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Discovering solution projects.
+        /// </summary>
+        public static string DiscoveringSolutionProjectsProgressMessage {
+            get {
+                return ResourceManager.GetString("DiscoveringSolutionProjectsProgressMessage", resourceCulture);
             }
         }
         
@@ -432,6 +450,15 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No projects in the current solution are applicable to the selected SonarQube project&apos;s quality profile..
+        /// </summary>
+        public static string NoProjectsApplicableForBinding {
+            get {
+                return ResourceManager.GetString("NoProjectsApplicableForBinding", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Field can not be empty.
         /// </summary>
         public static string NotEmptyValidatorRequiredField {
@@ -455,6 +482,15 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         public static string PathHelperAbsolutePathExpected {
             get {
                 return ResourceManager.GetString("PathHelperAbsolutePathExpected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Preparing binding steps.
+        /// </summary>
+        public static string PreparingBindingWorkflowProgessMessage {
+            get {
+                return ResourceManager.GetString("PreparingBindingWorkflowProgessMessage", resourceCulture);
             }
         }
         
@@ -753,6 +789,15 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         public static string UsernameRequired {
             get {
                 return ResourceManager.GetString("UsernameRequired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to VB.NET.
+        /// </summary>
+        public static string VBNetLanguageName {
+            get {
+                return ResourceManager.GetString("VBNetLanguageName", resourceCulture);
             }
         }
         

--- a/src/Integration/Resources/Strings.resx
+++ b/src/Integration/Resources/Strings.resx
@@ -458,4 +458,12 @@ This is the general format to use when writing errors to output window or when t
     <value>Discovering solution projects</value>
     <comment>Progress step message indicating projects are being discovered in the current solution</comment>
   </data>
+  <data name="InvalidTestProjectRegexPattern" xml:space="preserve">
+    <value>Test project regular expression pattern '{0}' is invalid. The default will be used instead. Please check your server settings.</value>
+    <comment>Warning output message indicating that the test project name regex was invalid. {0} invalid regex pattern</comment>
+  </data>
+  <data name="ProjectFilterDteProjectFailedToGetIVs" xml:space="preserve">
+    <value>Could not get the IVsHierarchy/IVsBuildPropertyStorage for the given project is IVsBuildPropertyStorage for the given EnvDTE.Project</value>
+    <comment>Exception message indicating was unable to get the equivalent IVs objects for the passed EnvDTE.Project.</comment>
+  </data>
 </root>

--- a/src/Integration/Resources/Strings.resx
+++ b/src/Integration/Resources/Strings.resx
@@ -438,4 +438,24 @@ This is the general format to use when writing errors to output window or when t
     <value>Warning: could not find CodeAnalysisRuleSet for project '{0}'</value>
     <comment>Warning message. '{0}' project unique name </comment>
   </data>
+  <data name="PreparingBindingWorkflowProgessMessage" xml:space="preserve">
+    <value>Preparing binding steps</value>
+    <comment>Binding progress message about preparing further binding steps</comment>
+  </data>
+  <data name="NoProjectsApplicableForBinding" xml:space="preserve">
+    <value>No projects in the current solution are applicable to the selected SonarQube project's quality profile.</value>
+    <comment>Output window message indicating the the current solution does not contain any projects that are applicable to the currently selected SonarQube project's quality profile.</comment>
+  </data>
+  <data name="CSharpLanguageName" xml:space="preserve">
+    <value>C#</value>
+    <comment>C# language name</comment>
+  </data>
+  <data name="VBNetLanguageName" xml:space="preserve">
+    <value>VB.NET</value>
+    <comment>VB.NET language name</comment>
+  </data>
+  <data name="DiscoveringSolutionProjectsProgressMessage" xml:space="preserve">
+    <value>Discovering solution projects</value>
+    <comment>Progress step message indicating projects are being discovered in the current solution</comment>
+  </data>
 </root>

--- a/src/Integration/Service/DataModel/ServerProperty.cs
+++ b/src/Integration/Service/DataModel/ServerProperty.cs
@@ -1,0 +1,29 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ServerProperty.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Newtonsoft.Json;
+using System.Diagnostics;
+
+namespace SonarLint.VisualStudio.Integration.Service
+{
+    [DebuggerDisplay("Key = {key}, Value = {value}")]
+    internal class ServerProperty
+    {
+        #region Known properties
+
+        public const string TestProjectRegexKey = "sonar.cs.msbuild.testProjectPattern";
+        public const string TestProjectRegexDefaultValue = @"[^\\]*test[^\\]*$";
+
+        #endregion
+
+        [JsonProperty("key")]
+        public string Key { get; set; }
+
+        [JsonProperty("value")]
+        public string Value { get; set; }
+    }
+}

--- a/src/Integration/Service/ISonarQubeServiceWrapper.cs
+++ b/src/Integration/Service/ISonarQubeServiceWrapper.cs
@@ -34,6 +34,11 @@ namespace SonarLint.VisualStudio.Integration.Service
         void Disconnect();
 
         /// <summary>
+        /// Retrieves all properties defined on the server specified by the <see cref="CurrentConnection"/>.
+        /// </summary>
+        IEnumerable<ServerProperty> GetProperties(CancellationToken token);
+
+        /// <summary>
         /// Retrieves the Roslyn Quality Profile export for the specified project using the <see cref="CurrentConnection"/>.
         /// </summary>
         /// <remarks>

--- a/src/TestInfrastructure/Framework/ConfigurableProjectSystemFilter.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableProjectSystemFilter.cs
@@ -1,0 +1,56 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ConfigurableProjectSystemFilter.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarLint.VisualStudio.Integration.Binding;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using DteProject = EnvDTE.Project;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests
+{
+    public class ConfigurableProjectSystemFilter : IProjectSystemFilter
+    {
+        public Regex TestRegex { get; set; }
+
+        public bool? AllProjectsMatchReturn { get; set; }
+
+        public List<DteProject> MatchingProjects { get; } = new List<DteProject>();
+
+        #region IProjectSystemFilter
+
+        bool IProjectSystemFilter.IsAccepted(DteProject dteProject)
+        {
+            if (this.AllProjectsMatchReturn.HasValue)
+            {
+                return this.AllProjectsMatchReturn.Value;
+            }
+
+            return this.MatchingProjects.Any(x => StringComparer.OrdinalIgnoreCase.Equals(x.UniqueName, dteProject.UniqueName));
+        }
+
+        void IProjectSystemFilter.SetTestRegex(Regex regex)
+        {
+            this.TestRegex = regex;
+        }
+
+        #endregion
+
+        #region Test Helpers
+
+        public void AssertTestRegex(string regex, RegexOptions options)
+        {
+            Assert.IsNotNull(this.TestRegex, "Expected test regex to be set");
+            Assert.AreEqual(regex, this.TestRegex.ToString(), "Unexpected test regular expression");
+            Assert.AreEqual(options, this.TestRegex.Options, "Unexpected test regex options");
+        }
+
+        #endregion
+    }
+}

--- a/src/TestInfrastructure/Framework/ConfigurableServiceProvider.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableServiceProvider.cs
@@ -18,11 +18,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
     /// </summary>
     public class ConfigurableServiceProvider : System.IServiceProvider, Microsoft.VisualStudio.OLE.Interop.IServiceProvider
     {
-        private Dictionary<Type, object> serviceInstances = new Dictionary<Type, object>(new TypeComparer());
-        private Dictionary<Type, Func<object>> serviceConstructors = new Dictionary<Type, Func<object>>(new TypeComparer());
+        private readonly Dictionary<Type, object> serviceInstances = new Dictionary<Type, object>(new TypeComparer());
+        private readonly Dictionary<Type, Func<object>> serviceConstructors = new Dictionary<Type, Func<object>>(new TypeComparer());
 
         // Records the services that were actually requested
-        private HashSet<Type> requestedServices = new HashSet<Type>();
+        private readonly HashSet<Type> requestedServices = new HashSet<Type>();
 
         #region Constructor(s)
 
@@ -119,14 +119,12 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         /// </summary>
         public void AssertServicesUsed(params Type[] expectedServiceTypes)
         {
-            if (expectedServiceTypes == null)
+            if (expectedServiceTypes != null)
             {
-                expectedServiceTypes = new Type[] { };
-            }
-
-            foreach (Type t in expectedServiceTypes)
-            {
-                this.AssertServiceUsed(t);
+                foreach (Type t in expectedServiceTypes)
+                {
+                    this.AssertServiceUsed(t);
+                }
             }
         }
 

--- a/src/TestInfrastructure/Framework/ConfigurableSonarQubeServiceWrapper.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableSonarQubeServiceWrapper.cs
@@ -25,7 +25,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
         public ProjectInformation[] ReturnProjectInformation { get; set; }
 
-        public IDictionary<string, ServerPlugin> ServerPlugins { get; } = new Dictionary<string, ServerPlugin>();
+        public ISet<ServerPlugin> ServerPlugins { get; } = new HashSet<ServerPlugin>();
+
+        public ISet<ServerProperty> ServerProperties { get; } = new HashSet<ServerProperty>();
 
         /// <summary>
         /// Language to rules map
@@ -67,12 +69,22 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
         public void RegisterServerPlugin(ServerPlugin plugin)
         {
-            this.ServerPlugins[plugin.Key] = plugin;
+            this.ServerPlugins.Add(plugin);
         }
 
         public void ClearServerPlugins()
         {
             this.ServerPlugins.Clear();
+        }
+
+        public void RegisterServerProperty(ServerProperty property)
+        {
+            this.ServerProperties.Add(property);
+        }
+
+        public void ClearServerProperties()
+        {
+            this.ServerProperties.Clear();
         }
 
         #endregion
@@ -124,7 +136,12 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
         public IEnumerable<ServerPlugin> GetPlugins(ConnectionInformation connectionInformation, CancellationToken token)
         {
-            return this.ServerPlugins.Values;
+            return this.ServerPlugins;
+        }
+
+        public IEnumerable<ServerProperty> GetProperties(CancellationToken token)
+        {
+            return this.ServerProperties;
         }
 
         #endregion

--- a/src/TestInfrastructure/Framework/ConfigurableVsProjectSystemHelper.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableVsProjectSystemHelper.cs
@@ -10,13 +10,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using EnvDTE80;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests
 {
     internal class ConfigurableVsProjectSystemHelper : IProjectSystemHelper
     {
         private readonly IServiceProvider serviceProvider;
-
+        
         public ConfigurableVsProjectSystemHelper(IServiceProvider serviceProvider)
         {
             this.serviceProvider = serviceProvider;
@@ -36,9 +37,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             return this.SolutionItemsProject;
         }
 
-        IEnumerable<Project> IProjectSystemHelper.GetSolutionManagedProjects()
+        IEnumerable<Project> IProjectSystemHelper.GetSolutionProjects()
         {
-            return this.ManagedProjects ?? Enumerable.Empty<Project>();
+            return this.Projects ?? Enumerable.Empty<Project>();
         }
 
         bool IProjectSystemHelper.IsFileInProject(Project project, string file)
@@ -74,13 +75,18 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             return this.CurrentActiveSolution;
         }
 
+        IVsHierarchy IProjectSystemHelper.GetIVsHierarchy(Project dteProject)
+        {
+            return dteProject as IVsHierarchy;
+        }
+
         #endregion
 
         #region Test helpers
 
         public Project SolutionItemsProject { get; set; }
 
-        public IEnumerable<Project> ManagedProjects { get; set; }
+        public IEnumerable<Project> Projects { get; set; }
 
         public Func<Project, string, bool> IsFileInProjectAction { get; set; }
 

--- a/src/TestInfrastructure/TestInfrastructure.csproj
+++ b/src/TestInfrastructure/TestInfrastructure.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Framework\ConfigurableHost.cs" />
     <Compile Include="Framework\ConfigurableIntegrationSettings.cs" />
     <Compile Include="Framework\ConfigurableProgressStepRunner.cs" />
+    <Compile Include="Framework\ConfigurableProjectSystemFilter.cs" />
     <Compile Include="Framework\ConfigurableSettingsManager.cs" />
     <Compile Include="Framework\ConfigurableSolutionRuleSetsInformationProvider.cs" />
     <Compile Include="Framework\ConfigurableSolutionRuleStore.cs" />


### PR DESCRIPTION
SonarQubeTestProject and SonarQubeExclude MSBuild properties are now detected and respected on bind. Also the test project regex (from the server) is taken into account when detecting a test project.