### PR TITLE
[SVS-13] Add Browse/View on web commands to server & project nodes

### DIFF
--- a/src/Integration.UnitTests/Service/SonarQubeServiceWrapperTests.cs
+++ b/src/Integration.UnitTests/Service/SonarQubeServiceWrapperTests.cs
@@ -464,6 +464,39 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             }
         }
 
+        [TestMethod]
+        public void SonarQubeServiceWrapper_CreateProjectDashboardUrl()
+        {
+            // Setup
+            var testSubject = new SonarQubeServiceWrapper(this.serviceProvider);
+
+            var serverUrl = new Uri("http://my-sonar-server:5555");
+            var connectionInfo = new ConnectionInformation(serverUrl);
+            var projectInfo = new ProjectInformation { Key = "p1" };
+
+            Uri expectedUrl = new Uri("http://my-sonar-server:5555/dashboard/index/p1");
+
+            // Act
+            var actualUrl = testSubject.CreateProjectDashboardUrl(connectionInfo, projectInfo);
+
+            // Verify
+            Assert.AreEqual(expectedUrl, actualUrl, "Unexpected project dashboard URL");
+        }
+
+        [TestMethod]
+        public void SonarQubeServiceWrapper_CreateProjectDashboardUrl_ArgChecks()
+        {
+            // Setup
+            var testSubject = new SonarQubeServiceWrapper(this.serviceProvider);
+
+            var connectionInfo = new ConnectionInformation(new Uri("http://my-sonar-server:5555"));
+            var projectInfo = new ProjectInformation { Key = "p1" };
+
+            // Act + Verify
+            Exceptions.Expect<ArgumentNullException>(() => testSubject.CreateProjectDashboardUrl(null, projectInfo));
+            Exceptions.Expect<ArgumentNullException>(() => testSubject.CreateProjectDashboardUrl(connectionInfo, null));
+        }
+
         #endregion
 
         #region Helpers

--- a/src/Integration.UnitTests/TeamExplorer/SectionControllerTests.cs
+++ b/src/Integration.UnitTests/TeamExplorer/SectionControllerTests.cs
@@ -46,6 +46,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             Assert.IsNotNull(testSubject.ConnectCommand, "ConnectCommand is not initialized");
             Assert.IsNotNull(testSubject.BindCommand, "BindCommand is not initialized");
             Assert.IsNotNull(testSubject.BrowseToUrlCommand, "BrowseToUrlCommand is not initialized");
+            Assert.IsNotNull(testSubject.BrowseToProjectDashboardCommand, "BrowseToProjectDashboardCommand is not initialized");
             Assert.IsNotNull(testSubject.DisconnectCommand, "DisconnectCommand is not initialized");
             Assert.IsNotNull(testSubject.RefreshCommand, "RefreshCommand is not initialized");
             Assert.IsNotNull(testSubject.ToggleShowAllProjectsCommand, "ToggleShowAllProjectsCommand is not initialized");
@@ -91,10 +92,12 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             // Verify
             Assert.IsNull(testSubject.ConnectCommand, "ConnectCommand is not cleared");
             Assert.IsNull(testSubject.RefreshCommand, "RefreshCommand is not cleared");
-            Assert.IsNull(testSubject.DisconnectCommand, "DisconnectCommand is not ;");
+            Assert.IsNull(testSubject.DisconnectCommand, "DisconnectCommand is not cleared");
             Assert.IsNull(testSubject.BindCommand, "BindCommand is not ;");
-            Assert.IsNull(testSubject.ToggleShowAllProjectsCommand, "ToggleShowAllProjectsCommand is not ;");
-            Assert.IsNull(testSubject.BrowseToUrlCommand, "BrowseToUrlCommand is not ;");
+            Assert.IsNull(testSubject.ToggleShowAllProjectsCommand, "ToggleShowAllProjectsCommand is not cleared");
+            Assert.IsNull(testSubject.BrowseToUrlCommand, "BrowseToUrlCommand is not cleared");
+            Assert.IsNull(testSubject.BrowseToProjectDashboardCommand, "BrowseToProjectDashboardCommand is not cleared");
+
         }
 
         [TestMethod]
@@ -256,6 +259,36 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             testSubject.BrowseToUrlCommand.Execute(goodUrl);
             webBrowser.AssertNavigateToCalls(1);
             webBrowser.AssertRequestToNavigateTo(goodUrl);
+        }
+
+        [TestMethod]
+        public void SectionController_BrowseToProjectDashboardCommand()
+        {
+            // Setup
+            var webBrowser = new ConfigurableWebBrowser();
+            var testSubject = this.CreateTestSubject(webBrowser);
+            var serverUrl = new Uri("http://my-sonar-server:5555");
+            var connectionInfo = new ConnectionInformation(serverUrl);
+            var projectInfo = new ProjectInformation { Key = "p1" };
+
+            Uri expectedUrl = new Uri(serverUrl, string.Format(SonarQubeServiceWrapper.ProjectDashboardRelativeUrl, projectInfo.Key));
+            this.sonarQubeService.RegisterProjectDashboardUrl(connectionInfo, projectInfo, expectedUrl);
+
+            // Case 1: Null parameter
+            // Act + Verify CanExecute
+            Assert.IsFalse(testSubject.BrowseToProjectDashboardCommand.CanExecute(null));
+
+            // Case 2: Project VM
+            var serverViewModel = new ServerViewModel(connectionInfo);
+            var projectViewModel = new ProjectViewModel(serverViewModel, projectInfo);
+
+            // Act + Verify CanExecute
+            Assert.IsTrue(testSubject.BrowseToProjectDashboardCommand.CanExecute(projectViewModel));
+
+            // Act + Verify Execute
+            testSubject.BrowseToProjectDashboardCommand.Execute(projectViewModel);
+            webBrowser.AssertNavigateToCalls(1);
+            webBrowser.AssertRequestToNavigateTo(expectedUrl.ToString());
         }
 
         #endregion

--- a/src/Integration/Resources/Strings.Designer.cs
+++ b/src/Integration/Resources/Strings.Designer.cs
@@ -124,6 +124,24 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Browser the server in your web browser..
+        /// </summary>
+        public static string BrowserServerMenuItemTooltip {
+            get {
+                return ResourceManager.GetString("BrowserServerMenuItemTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Browse.
+        /// </summary>
+        public static string BrowseServerMenuItemDisplayText {
+            get {
+                return ResourceManager.GetString("BrowseServerMenuItemDisplayText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Ca_ncel.
         /// </summary>
         public static string CancelButtonText {
@@ -477,7 +495,7 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Hide unbound projects.
+        ///   Looks up a localized string similar to Hide Unbound Projects.
         /// </summary>
         public static string HideUnboundProjectsCommandText {
             get {
@@ -748,7 +766,7 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Show all projects.
+        ///   Looks up a localized string similar to Show All Projects.
         /// </summary>
         public static string ShowAllProjectsCommandText {
             get {
@@ -924,6 +942,24 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         public static string VBNetLanguageName {
             get {
                 return ResourceManager.GetString("VBNetLanguageName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to View in SonarQube.
+        /// </summary>
+        public static string ViewInSonarQubeMenuItemDisplayText {
+            get {
+                return ResourceManager.GetString("ViewInSonarQubeMenuItemDisplayText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Open the dashboard for this project in SonarQube using your web browser..
+        /// </summary>
+        public static string ViewInSonarQubeMenuItemTooltip {
+            get {
+                return ResourceManager.GetString("ViewInSonarQubeMenuItemTooltip", resourceCulture);
             }
         }
         

--- a/src/Integration/Resources/Strings.resx
+++ b/src/Integration/Resources/Strings.resx
@@ -296,7 +296,7 @@ ocalization note: '[try again]()' is a special markup used to translate the text
     <comment>Button text for syncing an already bound SonarQube project to a VS solution</comment>
   </data>
   <data name="ShowAllProjectsCommandText" xml:space="preserve">
-    <value>Show all projects</value>
+    <value>Show All Projects</value>
     <comment>Server context menu command display text to show all projects (inc. unbound projects)</comment>
   </data>
   <data name="ToggleShowAllProjectsCommandTooltip" xml:space="preserve">
@@ -344,7 +344,7 @@ ocalization note: '[try again]()' is a special markup used to translate the text
     <comment>The place holder value in ConnectingToSonarQubePrefixMessageFormat</comment>
   </data>
   <data name="HideUnboundProjectsCommandText" xml:space="preserve">
-    <value>Hide unbound projects</value>
+    <value>Hide Unbound Projects</value>
     <comment>Server context menu command display text to show all projects (inc. unbound projects)</comment>
   </data>
   <data name="DownloadingQualityProfileProgressMessage" xml:space="preserve">
@@ -526,5 +526,21 @@ This is the general format to use when writing errors to output window or when t
     <value>Conflicting rules were removed from '{0}':</value>
     <comment>{0} - file path
 </comment>
+  </data>
+  <data name="ViewInSonarQubeMenuItemDisplayText" xml:space="preserve">
+    <value>View in SonarQube</value>
+    <comment>Menu item display text for the contextual command to view the SonarQube dashboard for the current item in the user's browser.</comment>
+  </data>
+  <data name="ViewInSonarQubeMenuItemTooltip" xml:space="preserve">
+    <value>Open the dashboard for this project in SonarQube using your web browser.</value>
+    <comment>Tooltip text for view project in SonarQube context menu item</comment>
+  </data>
+  <data name="BrowserServerMenuItemTooltip" xml:space="preserve">
+    <value>Browser the server in your web browser.</value>
+    <comment>Tooltip text for browser server context menu item</comment>
+  </data>
+  <data name="BrowseServerMenuItemDisplayText" xml:space="preserve">
+    <value>Browse</value>
+    <comment>Context menu item text for opening the server in the users's browser</comment>
   </data>
 </root>

--- a/src/Integration/Service/ISonarQubeServiceWrapper.cs
+++ b/src/Integration/Service/ISonarQubeServiceWrapper.cs
@@ -6,6 +6,7 @@
 //-----------------------------------------------------------------------
 
 using SonarLint.VisualStudio.Integration.Service.DataModel;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 
@@ -55,5 +56,12 @@ namespace SonarLint.VisualStudio.Integration.Service
         /// <param name="connectionInformation">Required connecting information</param>
         /// <returns>All server plugins, or null on connection failure</returns>
         IEnumerable<ServerPlugin> GetPlugins(ConnectionInformation connectionInformation, CancellationToken token);
+
+        /// <summary>
+        /// Generate a <see cref="Uri"/> to the dashboard for the given project on the provided <paramref name="connectionInformation"/>.
+        /// </summary>
+        /// <param name="connectionInformation">Server connection</param>
+        /// <param name="project">Project to generate the <see cref="Uri"/> for</param>
+        Uri CreateProjectDashboardUrl(ConnectionInformation connectionInformation, ProjectInformation project);
     }
 }

--- a/src/Integration/Service/SonarQubeServiceWrapper.cs
+++ b/src/Integration/Service/SonarQubeServiceWrapper.cs
@@ -37,6 +37,8 @@ namespace SonarLint.VisualStudio.Integration.Service
         public const string QualityProfileExportAPI   = "/profiles/export";                    // Since ???; internal
         public const string PropertiesAPI             = "/api/properties/";                    // Since 2.6
 
+        public const string ProjectDashboardRelativeUrl = "/dashboard/index/{0}";
+
         public const string RoslynExporter = "roslyn-cs";
 
         public const string CSharpLanguage = "cs";
@@ -143,6 +145,21 @@ namespace SonarLint.VisualStudio.Integration.Service
                 client => DownloadPluginInformation(client, token));
 
             return plugins;
+        }
+
+        public Uri CreateProjectDashboardUrl(ConnectionInformation connectionInformation, ProjectInformation project)
+        {
+            if (connectionInformation == null)
+            {
+                throw new ArgumentNullException(nameof(connectionInformation));
+            }
+
+            if (project == null)
+            {
+                throw new ArgumentNullException(nameof(project));
+            }
+
+            return new Uri(connectionInformation.ServerUri, string.Format(ProjectDashboardRelativeUrl, project.Key));
         }
 
         #endregion

--- a/src/Integration/State/StateManager.cs
+++ b/src/Integration/State/StateManager.cs
@@ -201,6 +201,7 @@ namespace SonarLint.VisualStudio.Integration.State
                 return;
             }
 
+
             var refreshContextualCommand = new ContextualCommandViewModel(serverVM, this.Host.ActiveSection.RefreshCommand)
             {
                 DisplayText = Strings.RefreshCommandDisplayText,
@@ -213,6 +214,13 @@ namespace SonarLint.VisualStudio.Integration.State
                 DisplayText = Strings.DisconnectCommandDisplayText,
                 Tooltip = Strings.DisconnectCommandTooltip,
                 Icon = new IconViewModel(KnownMonikers.Disconnect)
+            };
+
+            var browseServerContextualCommand = new ContextualCommandViewModel(serverVM.Url.ToString(), this.Host.ActiveSection.BrowseToUrlCommand)
+            {
+                DisplayText = Strings.BrowseServerMenuItemDisplayText,
+                Tooltip = Strings.BrowserServerMenuItemTooltip,
+                Icon = new IconViewModel(KnownMonikers.OpenWebSite)
             };
 
             var toggleShowAllProjectsCommand = new ContextualCommandViewModel(serverVM, this.Host.ActiveSection.ToggleShowAllProjectsCommand)
@@ -228,6 +236,7 @@ namespace SonarLint.VisualStudio.Integration.State
 
             serverVM.Commands.Add(refreshContextualCommand);
             serverVM.Commands.Add(disconnectContextualCommand);
+            serverVM.Commands.Add(browseServerContextualCommand);
             serverVM.Commands.Add(toggleShowAllProjectsCommand);
         }
 
@@ -257,7 +266,15 @@ namespace SonarLint.VisualStudio.Integration.State
                     return new IconViewModel(ctx?.IsBound ?? false ? KnownMonikers.Sync : KnownMonikers.Link);
                 });
 
+                var openProjectDashboardCommand = new ContextualCommandViewModel(projectVM, this.Host.ActiveSection.BrowseToProjectDashboardCommand)
+                {
+                    DisplayText = Strings.ViewInSonarQubeMenuItemDisplayText,
+                    Tooltip = Strings.ViewInSonarQubeMenuItemTooltip,
+                    Icon = new IconViewModel(KnownMonikers.OpenWebSite)
+                };
+
                 projectVM.Commands.Add(bindContextCommand);
+                projectVM.Commands.Add(openProjectDashboardCommand);
             }
         }
         #endregion

--- a/src/Integration/TeamExplorer/ISectionController.cs
+++ b/src/Integration/TeamExplorer/ISectionController.cs
@@ -41,6 +41,10 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
 
         ICommand BindCommand { get; }
 
+        ICommand BrowseToUrlCommand { get; }
+
+        ICommand BrowseToProjectDashboardCommand { get; }
+
         ICommand RefreshCommand { get; }
 
         ICommand DisconnectCommand { get; }

--- a/src/Integration/TeamExplorer/SectionController.cs
+++ b/src/Integration/TeamExplorer/SectionController.cs
@@ -9,6 +9,7 @@ using Microsoft.TeamFoundation.Client.CommandTarget;
 using Microsoft.TeamFoundation.Controls;
 using Microsoft.TeamFoundation.Controls.WPF.TeamExplorer;
 using SonarLint.VisualStudio.Integration.Progress;
+using SonarLint.VisualStudio.Integration.Service;
 using SonarLint.VisualStudio.Integration.WPF;
 using System;
 using System.Collections.Generic;
@@ -181,6 +182,12 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
             private set;
         }
 
+        public ICommand BrowseToProjectDashboardCommand
+        {
+            get;
+            private set;
+        }
+
         public ICommand RefreshCommand
         {
             get;
@@ -223,7 +230,7 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
             this.BindCommand = null;
 
             ISectionController section = (ISectionController)this;
-            if (section.ViewModel !=null)
+            if (section.ViewModel != null)
             {
                 section.ViewModel.ConnectCommand = null;
                 section.ViewModel.BindCommand = null;
@@ -237,6 +244,7 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
             this.DisconnectCommand = new RelayCommand(this.Disconnect, this.CanDisconnect);
             this.ToggleShowAllProjectsCommand = new RelayCommand<ServerViewModel>(this.ToggleShowAllProjects, this.CanToggleShowAllProjects);
             this.BrowseToUrlCommand = new RelayCommand<string>(this.ExecBrowseToUrl, this.CanExecBrowseToUrl);
+            this.BrowseToProjectDashboardCommand = new RelayCommand<ProjectViewModel>(this.ExecBrowseToProjectDashboard, this.CanExecBrowseToProjectDashboard);
         }
 
         private void CleanProvidedCommands()
@@ -244,6 +252,7 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
             this.DisconnectCommand = null;
             this.ToggleShowAllProjectsCommand = null;
             this.BrowseToUrlCommand = null;
+            this.BrowseToProjectDashboardCommand = null;
         }
 
         private void SyncCommands()
@@ -291,6 +300,27 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
 
             this.webBrowser.NavigateTo(url);
         }
+
+        private bool CanExecBrowseToProjectDashboard(ProjectViewModel project)
+        {
+            if (project != null)
+            {
+                var url = this.Host.SonarQubeService.CreateProjectDashboardUrl(project.Owner.ConnectionInformation, project.ProjectInformation);
+                return this.CanExecBrowseToUrl(url.ToString());
+            }
+
+            return false;
+        }
+
+        private void ExecBrowseToProjectDashboard(ProjectViewModel project)
+        {
+            Debug.Assert(this.CanExecBrowseToProjectDashboard(project), $"Shouldn't be able to execute {nameof(this.BrowseToProjectDashboardCommand)}");
+
+            var url = this.Host.SonarQubeService.CreateProjectDashboardUrl(project.Owner.ConnectionInformation, project.ProjectInformation);
+            this.ExecBrowseToUrl(url.ToString());
+        }
+
         #endregion
+
     }
 }

--- a/src/Integration/TeamExplorer/ServerViewModel.cs
+++ b/src/Integration/TeamExplorer/ServerViewModel.cs
@@ -61,6 +61,11 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
 
         #region Properties
 
+        public ConnectionInformation ConnectionInformation
+        {
+            get { return this.connectionInformation; }
+        }
+
         public bool ShowAllProjects
         {
             get { return this.showAllProjects; }

--- a/src/TestInfrastructure/Framework/ConfigurableSectionController.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableSectionController.cs
@@ -68,6 +68,18 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             get;
             set;
         }
+
+        public ICommand BrowseToUrlCommand
+        {
+            get;
+            set;
+        }
+
+        public ICommand BrowseToProjectDashboardCommand
+        {
+            get;
+            set;
+        }
         #endregion
 
         public static ConfigurableSectionController CreateDefault()
@@ -81,6 +93,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             section.ConnectCommand = new RelayCommand(() => { });
             section.DisconnectCommand = new RelayCommand(() => { });
             section.RefreshCommand = new RelayCommand(() => { });
+            section.BrowseToUrlCommand = new RelayCommand(() => { });
+            section.BrowseToProjectDashboardCommand = new RelayCommand(() => { });
             section.ToggleShowAllProjectsCommand = new RelayCommand(() => { });
             return section;
         }

--- a/src/TestInfrastructure/Framework/ConfigurableSonarQubeServiceWrapper.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableSonarQubeServiceWrapper.cs
@@ -19,6 +19,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         private ConnectionInformation connection;
         private int connectRequestsCount;
         private int disconnectRequestsCount;
+        private readonly IDictionary<string, IDictionary<string, Uri>> projectDashboardUrls = new Dictionary<string, IDictionary<string, Uri>>();
 
         #region Testing helpers
         public bool AllowConnections { get; set; } = true;
@@ -87,6 +88,19 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             this.ServerProperties.Clear();
         }
 
+
+        public void RegisterProjectDashboardUrl(ConnectionInformation connectionInfo, ProjectInformation projectInfo, Uri url)
+        {
+            var serverUrl = connectionInfo.ServerUri.ToString();
+            var projectKey = projectInfo.Key;
+            if (!this.projectDashboardUrls.ContainsKey(serverUrl))
+            {
+                this.projectDashboardUrls[serverUrl] = new Dictionary<string, Uri>();
+            }
+
+            this.projectDashboardUrls[serverUrl][projectKey] = url;
+        }
+
         #endregion
 
         #region ISonarQubeServiceWrapper
@@ -142,6 +156,18 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         public IEnumerable<ServerProperty> GetProperties(CancellationToken token)
         {
             return this.ServerProperties;
+        }
+
+        public Uri CreateProjectDashboardUrl(ConnectionInformation connectionInformation, ProjectInformation project)
+        {
+            Uri url;
+            IDictionary<string, Uri> projects;
+            if (this.projectDashboardUrls.TryGetValue(connectionInformation.ServerUri.ToString(), out projects) 
+                && projects.TryGetValue(project.Key, out url))
+            {
+                return url;
+            }
+            return null;
         }
 
         #endregion


### PR DESCRIPTION
- Added a "Browse" command to the server node in the Team Explorer to open the user's preferred web browser at the server's URL.
- Added a "View in SonarQube" command to the project nodes (under a server) to also open the user's browser at the project dashboard.