### PR TITLE
[SVS-78] Fix issue with request URL construction

### DIFF
--- a/src/Integration.UnitTests/Integration.UnitTests.csproj
+++ b/src/Integration.UnitTests/Integration.UnitTests.csproj
@@ -170,6 +170,7 @@
     <Compile Include="TeamExplorer\SonarQubePageTests.cs" />
     <Compile Include="TeamExplorer\TeamExplorerControllerTests.cs" />
     <Compile Include="TelemetryLoggerAccessorTests.cs" />
+    <Compile Include="UriExtensionsTests.cs" />
     <Compile Include="VsSessionHostTests.cs" />
     <Compile Include="VsShellUtilsTests.cs" />
     <Compile Include="WPF\BoolToVisibilityConverterTests.cs" />

--- a/src/Integration.UnitTests/Service/ConnectionInformationTests.cs
+++ b/src/Integration.UnitTests/Service/ConnectionInformationTests.cs
@@ -21,7 +21,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var userName = "admin";
             var passwordUnsecure = "admin";
             var password = passwordUnsecure.ConvertToSecureString();
-            var serverUri = new Uri("http://localhost");
+            var serverUri = new Uri("http://localhost/");
             var testSubject = new ConnectionInformation(serverUri, userName, password);
 
             // Act
@@ -51,7 +51,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         public void ConnectionInformation_WithoutLoginInformation()
         {
             // Setup
-            var serverUri = new Uri("http://localhost");
+            var serverUri = new Uri("http://localhost/");
 
             // Act
             var testSubject = new ConnectionInformation(serverUri);
@@ -65,9 +65,18 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var testSubject2 = (ConnectionInformation)((ICloneable)testSubject).Clone();
 
             // Verify testSubject2
-            Assert.IsNull(testSubject.Password, "Password wasn't provided");
-            Assert.IsNull(testSubject.UserName, "UserName wasn't provided");
-            Assert.AreEqual(serverUri, testSubject.ServerUri, "ServerUri doesn't match");
+            Assert.IsNull(testSubject2.Password, "Password wasn't provided");
+            Assert.IsNull(testSubject2.UserName, "UserName wasn't provided");
+            Assert.AreEqual(serverUri, testSubject2.ServerUri, "ServerUri doesn't match");
         }
+
+        [TestMethod]
+        public void ConnectionInformation_Ctor_NormalizesServerUri()
+        {
+            // Act
+            var noSlashResult = new ConnectionInformation(new Uri("http://localhost/NoSlash"));
+
+            // Verify
+            Assert.AreEqual("http://localhost/NoSlash/", noSlashResult.ServerUri.ToString(), "Unexpected normalisation of URI without trailing slash");        }
     }
 }

--- a/src/Integration.UnitTests/UriExtensionsTests.cs
+++ b/src/Integration.UnitTests/UriExtensionsTests.cs
@@ -1,0 +1,42 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="UriExtensionsTests.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests
+{
+    [TestClass]
+    public class UriExtensionsTests
+    {
+        [TestMethod]
+        public void UriExtensions_NullArgChecks()
+        {
+            Exceptions.Expect<ArgumentNullException>(() => UriExtensions.EnsureTrailingSlash(null));
+        }
+
+        [TestMethod]
+        public void UriExtensions_EnsureTrailingSlash_NoTrailingSlash_AppendsSlash()
+        {
+            // Act
+            var noSlashResult = UriExtensions.EnsureTrailingSlash(new Uri("http://localhost/NoSlash"));
+
+            // Verify
+            Assert.AreEqual("http://localhost/NoSlash/", noSlashResult.ToString(), "Unexpected normalisation of URI without trailing slash");
+        }
+
+        [TestMethod]
+        public void UriExtensions_EnsureTrailingSlash_HasTrailingSlash_ReturnsSameInstance()
+        {
+            // Act
+            var withSlashResult = UriExtensions.EnsureTrailingSlash(new Uri("http://localhost/WithSlash/"));
+
+            // Verify
+            Assert.AreEqual("http://localhost/WithSlash/", withSlashResult.ToString(), "Unexpected normalisation of URI already with trailing slash");
+        }
+    }
+}

--- a/src/Integration/Integration.csproj
+++ b/src/Integration/Integration.csproj
@@ -213,6 +213,7 @@
     <Compile Include="ActiveSolutionTracker.cs" />
     <Compile Include="TeamExplorer\ISectionController.cs" />
     <Compile Include="TelemetryLoggerAccessor.cs" />
+    <Compile Include="UriExtensions.cs" />
     <Compile Include="VsSessionHost.cs" />
     <Compile Include="WebBrowser.cs" />
     <Compile Include="WPF\ContextualCommandsCollection.cs" />

--- a/src/Integration/Service/DataModel/ConnectionInformation.cs
+++ b/src/Integration/Service/DataModel/ConnectionInformation.cs
@@ -15,7 +15,7 @@ namespace SonarLint.VisualStudio.Integration.Service
     /// </summary>
     internal class ConnectionInformation : ICloneable, IDisposable
     {
-        private bool isDisposed = false;
+        private bool isDisposed;
 
         internal ConnectionInformation(Uri serverUri, string userName, SecureString password)
         {
@@ -24,10 +24,10 @@ namespace SonarLint.VisualStudio.Integration.Service
                 throw new ArgumentNullException(nameof(serverUri));
             }
 
-            this.ServerUri = serverUri;
+            this.ServerUri = serverUri.EnsureTrailingSlash();
             this.UserName = userName;
             this.Password = password?.CopyAsReadOnly();
-            this.Authentication = AuthenticationType.Basic; // Only once supported at this point
+            this.Authentication = AuthenticationType.Basic; // Only one supported at this point
         }
 
         internal ConnectionInformation(Uri serverUri)

--- a/src/Integration/Service/SonarQubeServiceWrapper.cs
+++ b/src/Integration/Service/SonarQubeServiceWrapper.cs
@@ -31,13 +31,13 @@ namespace SonarLint.VisualStudio.Integration.Service
     [Export(typeof(SonarQubeServiceWrapper)), PartCreationPolicy(CreationPolicy.Shared)]
     internal class SonarQubeServiceWrapper : ISonarQubeServiceWrapper
     {
-        public const string ProjectsAPI               = "/api/projects/index";                 // Since 2.10
-        public const string ServerPluginsInstalledAPI = "/api/updatecenter/installed_plugins"; // Since 2.10; internal
-        public const string QualityProfileListAPI     = "/api/profiles/list";                  // Since 3.3; deprecated in 5.2
-        public const string QualityProfileExportAPI   = "/profiles/export";                    // Since ???; internal
-        public const string PropertiesAPI             = "/api/properties/";                    // Since 2.6
+        public const string ProjectsAPI               = "api/projects/index";                 // Since 2.10
+        public const string ServerPluginsInstalledAPI = "api/updatecenter/installed_plugins"; // Since 2.10; internal
+        public const string QualityProfileListAPI     = "api/profiles/list";                  // Since 3.3; deprecated in 5.2
+        public const string QualityProfileExportAPI   = "profiles/export";                    // Since ???; internal
+        public const string PropertiesAPI             = "api/properties/";                    // Since 2.6
 
-        public const string ProjectDashboardRelativeUrl = "/dashboard/index/{0}";
+        public const string ProjectDashboardRelativeUrl = "dashboard/index/{0}";
 
         public const string RoslynExporter = "roslyn-cs";
 
@@ -202,11 +202,11 @@ namespace SonarLint.VisualStudio.Integration.Service
         {
             if (project == null)
             {
-                return CreateUrl(QualityProfileListAPI, "?language={0}", language);
+                return AppendQueryString(QualityProfileListAPI, "?language={0}", language);
             }
             else
             {
-                return CreateUrl(QualityProfileListAPI, "?language={0}&project={1}", language, project.Key);
+                return AppendQueryString(QualityProfileListAPI, "?language={0}&project={1}", language, project.Key);
             }
         }
 
@@ -237,7 +237,7 @@ namespace SonarLint.VisualStudio.Integration.Service
 
         internal /*for testing purposes*/ static string CreateQualityProfileExportUrl(QualityProfile profile, string language, string exporter)
         {
-            return CreateUrl(QualityProfileExportAPI, "?name={0}&language={1}&format={2}", profile.Name, language, exporter);
+            return AppendQueryString(QualityProfileExportAPI, "?name={0}&language={1}&format={2}", profile.Name, language, exporter);
         }
 
         private async Task<RoslynExportProfile> DownloadExportForProject(HttpClient client, ProjectInformation project, string language, CancellationToken token)
@@ -279,14 +279,29 @@ namespace SonarLint.VisualStudio.Integration.Service
 
         #region Helpers
 
-        private static string CreateUrl(string urlBase, string queryFormat, params string[] args)
+        internal /*for testing purposes*/ static string AppendQueryString(string urlBase, string queryFormat, params string[] args)
         {
             return urlBase + string.Format(CultureInfo.InvariantCulture, queryFormat, args.Select(HttpUtility.UrlEncode).ToArray());
         }
 
+        internal /*for testing purposes*/ static Uri CreateRequestUrl(HttpClient client, string apiUrl)
+        {
+            // We normalise these inputs to that the client base address always has a trailing slash,
+            // and the API url has no leading slash.
+            // Failure to do so will cause an incorrect URL to be formed, with the apiUrl being relative
+            // to the base address's hostname only.
+            Debug.Assert(client.BaseAddress.ToString().EndsWith("/"), "HttpClient.BaseAddress should have a trailing slash");
+            Debug.Assert(!apiUrl.StartsWith("/"), "API URLs should not begin with a slash as this forces the API to be relative to the base URI's hostname.");
+
+            Uri normalBaseUri = client.BaseAddress.EnsureTrailingSlash();
+            string normalApiUrl = apiUrl.TrimStart('/');
+
+            return new Uri(normalBaseUri, normalApiUrl);
+        }
+
         private static async Task<HttpResponseMessage> InvokeGetRequest(HttpClient client, string apiUrl, CancellationToken token, bool ensureSuccess = true)
         {
-            var uri = new Uri(client.BaseAddress, apiUrl);
+            var uri = CreateRequestUrl(client, apiUrl);
             HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, uri);
             HttpResponseMessage response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, token).ConfigureAwait(false);
 

--- a/src/Integration/UriExtensions.cs
+++ b/src/Integration/UriExtensions.cs
@@ -1,0 +1,31 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="UriExtensions.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+
+namespace SonarLint.VisualStudio.Integration
+{
+    internal static class UriExtensions
+    {
+        public static Uri EnsureTrailingSlash(this Uri uri)
+        {
+            if (uri == null)
+            {
+                throw new ArgumentNullException(nameof(uri));
+            }
+
+            var uriString = uri.ToString();
+
+            if (!uriString.EndsWith("/"))
+            {
+                return new Uri(uriString + "/");
+            }
+
+            return uri;
+        }
+    }
+}


### PR DESCRIPTION
When the request Uri was being constructed, the presence of the leading slash on the API URI paths forced the path to be relative to the root of the base address (the hostname).

Strengthened against inconsistencies with leading & trailing slashes when combining Uri parts.