### PR TITLE
[Technical] rename SolutionBinding

### DIFF
--- a/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
+++ b/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
@@ -47,11 +47,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
             var sccFileSystem = new ConfigurableSourceControlledFileSystem();
             var ruleSerializer = new ConfigurableRuleSetSerializer(sccFileSystem);
-            var solutionBinding = new ConfigurableSolutionBinding();
+            var solutionBinding = new ConfigurableSolutionBindingSerializer();
 
             this.serviceProvider.RegisterService(typeof(ISourceControlledFileSystem), sccFileSystem);
             this.serviceProvider.RegisterService(typeof(IRuleSetSerializer), ruleSerializer);
-            this.serviceProvider.RegisterService(typeof(ISolutionBinding), solutionBinding);
+            this.serviceProvider.RegisterService(typeof(ISolutionBindingSerializer), solutionBinding);
             this.serviceProvider.RegisterService(typeof(IProjectSystemHelper), this.projectSystemHelper);
         }
 

--- a/src/Integration.UnitTests/Binding/SolutionBindingOperationTests.cs
+++ b/src/Integration.UnitTests/Binding/SolutionBindingOperationTests.cs
@@ -30,7 +30,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         private SolutionMock solutionMock;
         private ConfigurableSourceControlledFileSystem sccFileSystem;
         private ConfigurableRuleSetSerializer ruleFS;
-        private ConfigurableSolutionBinding solutionBinding;
+        private ConfigurableSolutionBindingSerializer solutionBinding;
         private ConfigurableSolutionRuleSetsInformationProvider ruleSetInfo;
 
         private const string SolutionRoot = @"c:\solution";
@@ -52,7 +52,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             this.projectSystemHelper.CurrentActiveSolution = this.solutionMock;
             this.sccFileSystem  = new ConfigurableSourceControlledFileSystem();
             this.ruleFS = new ConfigurableRuleSetSerializer(this.sccFileSystem);
-            this.solutionBinding = new ConfigurableSolutionBinding();
+            this.solutionBinding = new ConfigurableSolutionBindingSerializer();
             this.ruleSetInfo = new ConfigurableSolutionRuleSetsInformationProvider();
             this.ruleSetInfo.SolutionRootFolder = SolutionRoot;
 
@@ -293,7 +293,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         public void SolutionBindingOperation_CommitSolutionBinding()
         {
             // Setup
-            this.serviceProvider.RegisterService(typeof(Persistence.ISolutionBinding), this.solutionBinding);
+            this.serviceProvider.RegisterService(typeof(Persistence.ISolutionBindingSerializer), this.solutionBinding);
             var csProject = this.solutionMock.AddOrGetProject("CS.csproj");
             csProject.SetCSProjectKind();
             var projects = new[] { csProject };

--- a/src/Integration.UnitTests/Integration.UnitTests.csproj
+++ b/src/Integration.UnitTests/Integration.UnitTests.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Framework\ConfigurableCredentialStore.cs" />
     <Compile Include="IServiceProviderExtensionsTests.cs" />
     <Compile Include="LocalServices\RuleSetSerializerTests.cs" />
+    <Compile Include="Persistence\SolutionBindingSerializerTests.cs" />
     <Compile Include="ProfileConflicts\ConflictsManagerTests.cs" />
     <Compile Include="ProfileConflicts\FixedRuleSetInfoTests.cs" />
     <Compile Include="ProfileConflicts\RuleConflictInfoTests.cs" />
@@ -149,7 +150,6 @@
     <Compile Include="LocalServices\SourceControlledFileSystemTests.cs" />
     <Compile Include="PathHelperTests.cs" />
     <Compile Include="Persistence\BoundSonarQubeProjectTests.cs" />
-    <Compile Include="Persistence\SolutionBindingTests.cs" />
     <Compile Include="Progress\ProgressNotificationListenerTests.cs" />
     <Compile Include="Progress\ProgressStepRunnerTests.cs" />
     <Compile Include="LocalServices\ProjectSystemFilterTests.cs" />

--- a/src/Integration.UnitTests/Persistence/SolutionBindingSerializerTests.cs
+++ b/src/Integration.UnitTests/Persistence/SolutionBindingSerializerTests.cs
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------
-// <copyright file="SolutionBindingTests.cs" company="SonarSource SA and Microsoft Corporation">
+// <copyright file="SolutionBindingSerializerTests.cs" company="SonarSource SA and Microsoft Corporation">
 //   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
 //   Licensed under the MIT License. See License.txt in the project root for license information.
 // </copyright>
@@ -15,7 +15,7 @@ using System.IO;
 namespace SonarLint.VisualStudio.Integration.UnitTests
 {
     [TestClass]
-    public class SolutionBindingTests
+    public class SolutionBindingSerializerTests
     {
         private ConfigurableServiceProvider serviceProvider;
         private ConfigurableVsGeneralOutputWindowPane outputPane;
@@ -49,27 +49,27 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         }
 
         [TestMethod]
-        public void SolutionBinding_ArgChecks()
+        public void SolutionBindingSerializer_ArgChecks()
         {
-            Exceptions.Expect<ArgumentNullException>(() => new SolutionBinding(null));
-            Exceptions.Expect<ArgumentNullException>(() => new SolutionBinding(this.serviceProvider, null));
+            Exceptions.Expect<ArgumentNullException>(() => new SolutionBindingSerializer(null));
+            Exceptions.Expect<ArgumentNullException>(() => new SolutionBindingSerializer(this.serviceProvider, null));
         }
 
         [TestMethod]
-        public void SolutionBinding_WriteSolutionBinding_ArgChecks()
+        public void SolutionBindingSerializer_WriteSolutionBinding_ArgChecks()
         {
             // Setup
-            SolutionBinding testSubject = this.CreateTestSubject();
+            SolutionBindingSerializer testSubject = this.CreateTestSubject();
 
             // Act + Verify
             Exceptions.Expect<ArgumentNullException>(() => testSubject.WriteSolutionBinding(null));
         }
 
         [TestMethod]
-        public void SolutionBinding_WriteSolutionBinding_ReadSolutionBinding()
+        public void SolutionBindingSerializer_WriteSolutionBinding_ReadSolutionBinding()
         {
             // Setup
-            SolutionBinding testSubject = this.CreateTestSubject();
+            SolutionBindingSerializer testSubject = this.CreateTestSubject();
             var serverUri = new Uri("http://xxx.www.zzz/yyy:9000");
             var creds = new BasicAuthCredentials("user", "pwd".ConvertToSecureString());
             var projectKey = "MyProject Key";
@@ -98,10 +98,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         }
 
         [TestMethod]
-        public void SolutionBinding_WriteSolutionBinding_ReadSolutionBinding_OnRealStore()
+        public void SolutionBindingSerializer_WriteSolutionBinding_ReadSolutionBinding_OnRealStore()
         {
             // Setup
-            var testSubject = new SolutionBinding(this.serviceProvider);
+            var testSubject = new SolutionBindingSerializer(this.serviceProvider);
             var serverUri = new Uri("http://xxx.www.zzz/yyy:9000");
             var projectKey = "MyProject Key";
             testSubject.Store.DeleteCredentials(serverUri);
@@ -154,10 +154,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         }
 
         [TestMethod]
-        public void SolutionBinding_ReadSolutionBinding_InvalidData()
+        public void SolutionBindingSerializer_ReadSolutionBinding_InvalidData()
         {
             // Setup
-            SolutionBinding testSubject = this.CreateTestSubject();
+            SolutionBindingSerializer testSubject = this.CreateTestSubject();
             var serverUri = new Uri("http://xxx.www.zzz/yyy:9000");
             var creds = new BasicAuthCredentials("user", "pwd".ConvertToSecureString());
             var projectKey = "MyProject Key";
@@ -176,10 +176,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         }
 
         [TestMethod]
-        public void SolutionBinding_ReadSolutionBinding_NoFile()
+        public void SolutionBindingSerializer_ReadSolutionBinding_NoFile()
         {
             // Setup
-            SolutionBinding testSubject = this.CreateTestSubject();
+            SolutionBindingSerializer testSubject = this.CreateTestSubject();
 
             // Act (read)
             BoundSonarQubeProject read = testSubject.ReadSolutionBinding();
@@ -189,11 +189,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             this.outputPane.AssertOutputStrings(0);
         }
 
-
-        public void SolutionBinding_ReadSolutionBinding_IOError()
+        [TestMethod]
+        public void SolutionBindingSerializer_ReadSolutionBinding_IOError()
         {
             // Setup
-            SolutionBinding testSubject = this.CreateTestSubject();
+            SolutionBindingSerializer testSubject = this.CreateTestSubject();
             var serverUri = new Uri("http://xxx.www.zzz/yyy:9000");
             var creds = new BasicAuthCredentials("user", "pwd".ConvertToSecureString());
             var projectKey = "MyProject Key";
@@ -212,10 +212,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         }
 
         [TestMethod]
-        public void SolutionBinding_WriteSolutionBinding_IOError()
+        public void SolutionBindingSerializer_WriteSolutionBinding_IOError()
         {
             // Setup
-            SolutionBinding testSubject = this.CreateTestSubject();
+            SolutionBindingSerializer testSubject = this.CreateTestSubject();
             var serverUri = new Uri("http://xxx.www.zzz/yyy:9000");
             var creds = new BasicAuthCredentials("user", "pwd".ConvertToSecureString());
             var projectKey = "MyProject Key";
@@ -236,10 +236,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         }
 
         [TestMethod]
-        public void SolutionBinding_WriteSolutionBinding_AddConfigFileToSolutionItemsFolder()
+        public void SolutionBindingSerializer_WriteSolutionBinding_AddConfigFileToSolutionItemsFolder()
         {
             // Setup
-            SolutionBinding testSubject = this.CreateTestSubject();
+            SolutionBindingSerializer testSubject = this.CreateTestSubject();
             var serverUri = new Uri("http://xxx.www.zzz/yyy:9000");
             var creds = new BasicAuthCredentials("user", "pwd".ConvertToSecureString());
             var projectKey = "MyProject Key";
@@ -271,9 +271,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         }
 
         #region Helpers
-        private SolutionBinding CreateTestSubject()
+        private SolutionBindingSerializer CreateTestSubject()
         {
-            return new SolutionBinding(this.serviceProvider, this.store);
+            return new SolutionBindingSerializer(this.serviceProvider, this.store);
         }
         #endregion
     }

--- a/src/Integration.UnitTests/ProfileConflicts/ConflictsManagerTests.cs
+++ b/src/Integration.UnitTests/ProfileConflicts/ConflictsManagerTests.cs
@@ -25,7 +25,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         private ConfigurableVsProjectSystemHelper projectHelper;
         private ConfigurableSolutionRuleSetsInformationProvider ruleSetInfoProvider;
         private ConfigurableFileSystem fileSystem;
-        private ConfigurableSolutionBinding solutionBinding;
+        private ConfigurableSolutionBindingSerializer solutionBinding;
         private ConfigurableRuleSetInspector inspector;
         private ConfigurableVsGeneralOutputWindowPane outputWindow;
         private DTEMock dte;
@@ -47,8 +47,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             this.fileSystem = new ConfigurableFileSystem();
             this.serviceProvider.RegisterService(typeof(IFileSystem), this.fileSystem);
 
-            this.solutionBinding = new ConfigurableSolutionBinding();
-            this.serviceProvider.RegisterService(typeof(ISolutionBinding), this.solutionBinding);
+            this.solutionBinding = new ConfigurableSolutionBindingSerializer();
+            this.serviceProvider.RegisterService(typeof(ISolutionBindingSerializer), this.solutionBinding);
 
             this.inspector = new ConfigurableRuleSetInspector();
             this.serviceProvider.RegisterService(typeof(IRuleSetInspector), this.inspector);

--- a/src/Integration.UnitTests/SonarAnalyzer/ActiveSolutionBoundTrackerTests.cs
+++ b/src/Integration.UnitTests/SonarAnalyzer/ActiveSolutionBoundTrackerTests.cs
@@ -54,11 +54,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.SonarAnalyzer
         public void ActiveSolutionBoundTracker_Unbound()
         {
             // Setup
-            var solutionBinding = new ConfigurableSolutionBinding
+            var solutionBinding = new ConfigurableSolutionBindingSerializer
             {
                 CurrentBinding = null
             };
-            this.serviceProvider.RegisterService(typeof(ISolutionBinding), solutionBinding);
+            this.serviceProvider.RegisterService(typeof(ISolutionBindingSerializer), solutionBinding);
             host.VisualStateManager.SetBoundProject(new ProjectInformation());
             var testSubject = new ActiveSolutionBoundTracker(this.host, this.activeSolutionTracker);
 
@@ -70,11 +70,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.SonarAnalyzer
         public void ActiveSolutionBoundTracker_Bound()
         {
             // Setup
-            var solutionBinding = new ConfigurableSolutionBinding
+            var solutionBinding = new ConfigurableSolutionBindingSerializer
             {
                 CurrentBinding = new BoundSonarQubeProject()
             };
-            this.serviceProvider.RegisterService(typeof(ISolutionBinding), solutionBinding);
+            this.serviceProvider.RegisterService(typeof(ISolutionBindingSerializer), solutionBinding);
             host.VisualStateManager.SetBoundProject(new ProjectInformation());
             var testSubject = new ActiveSolutionBoundTracker(this.host, this.activeSolutionTracker);
 
@@ -86,11 +86,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.SonarAnalyzer
         public void ActiveSolutionBoundTracker_Changes()
         {
             // Setup
-            var solutionBinding = new ConfigurableSolutionBinding
+            var solutionBinding = new ConfigurableSolutionBindingSerializer
             {
                 CurrentBinding = new BoundSonarQubeProject()
             };
-            this.serviceProvider.RegisterService(typeof(ISolutionBinding), solutionBinding);
+            this.serviceProvider.RegisterService(typeof(ISolutionBindingSerializer), solutionBinding);
             var testSubject = new ActiveSolutionBoundTracker(this.host, this.activeSolutionTracker);
 
             // Sanity

--- a/src/Integration.UnitTests/VsSessionHostTests.cs
+++ b/src/Integration.UnitTests/VsSessionHostTests.cs
@@ -22,7 +22,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
         private ConfigurableSonarQubeServiceWrapper sonarQubeService;
         private ConfigurableStateManager stateManager;
         private ConfigurableProgressStepRunner stepRunner;
-        private ConfigurableSolutionBinding solutionBinding;
+        private ConfigurableSolutionBindingSerializer solutionBinding;
 
         public TestContext TestContext { get; set; }
 
@@ -33,7 +33,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             this.serviceProvider = new ConfigurableServiceProvider(assertOnUnexpectedServiceRequest: false);
             this.sonarQubeService = new ConfigurableSonarQubeServiceWrapper();
             this.stepRunner = new ConfigurableProgressStepRunner();
-            this.solutionBinding = new ConfigurableSolutionBinding();
+            this.solutionBinding = new ConfigurableSolutionBindingSerializer();
         }
 
         #region Tests
@@ -322,12 +322,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
 
             this.stateManager.Host = host;
 
-            host.ReplaceInternalServiceForTesting<ISolutionBinding>(this.solutionBinding);
+            host.ReplaceInternalServiceForTesting<ISolutionBindingSerializer>(this.solutionBinding);
 
             return host;
         }
 
-      
         #endregion
     }
 }

--- a/src/Integration.Vsix.UnitTests/Telemetry/BoundSolutionAnalyzerTests.cs
+++ b/src/Integration.Vsix.UnitTests/Telemetry/BoundSolutionAnalyzerTests.cs
@@ -141,7 +141,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
                 Directory.CreateDirectory(directory);
             }
 
-            File.WriteAllText(Path.Combine(directory, SolutionBinding.SonarQubeSolutionBindingConfigurationFileName), string.Empty);
+            File.WriteAllText(Path.Combine(directory, SolutionBindingSerializer.SonarQubeSolutionBindingConfigurationFileName), string.Empty);
         }
 
         private static void DeleteBindingInformationFile(string directory)

--- a/src/Integration/Binding/SolutionBindingOperation.cs
+++ b/src/Integration/Binding/SolutionBindingOperation.cs
@@ -205,7 +205,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
         /// </summary>
         private void PendBindingInformation(ConnectionInformation connInfo)
         {
-            var binding = this.serviceProvider.GetService<ISolutionBinding>();
+            var binding = this.serviceProvider.GetService<ISolutionBindingSerializer>();
             binding.AssertLocalServiceIsNotNull();
 
             BasicAuthCredentials credentials = connection.UserName == null ? null : new BasicAuthCredentials(connInfo.UserName, connInfo.Password);

--- a/src/Integration/Integration.csproj
+++ b/src/Integration/Integration.csproj
@@ -148,7 +148,7 @@
     <Compile Include="LocalServices\RuleSetDeclaration.cs" />
     <Compile Include="ProfileConflicts\RuleSetInspector.cs" />
     <Compile Include="LocalServices\SolutionRuleSetsInformationProvider.cs" />
-    <Compile Include="Persistence\ISolutionBinding.cs" />
+    <Compile Include="Persistence\ISolutionBindingSerializer.cs" />
     <Compile Include="Progress\IProgressStepRunnerWrapper.cs" />
     <Compile Include="ProfileConflicts\RuleSetConflictsController.cs" />
     <Compile Include="RuleSetHelper.cs" />
@@ -192,7 +192,7 @@
     <Compile Include="Persistence\Microsoft.Alm.Authentication\TokenType.cs" />
     <Compile Include="PathHelper.cs" />
     <Compile Include="Persistence\ICredentials.cs" />
-    <Compile Include="Persistence\SolutionBinding.cs" />
+    <Compile Include="Persistence\SolutionBindingSerializer.cs" />
     <Compile Include="Progress\IProgressControlHost.cs" />
     <Compile Include="Progress\ProgressNotificationListener.cs" />
     <Compile Include="Service\AuthenticationHeaderProvider.cs" />
@@ -300,6 +300,7 @@
     <Analyzer Include="..\..\packages\SonarLint.1.7.0\analyzers\SonarLint.CSharp.dll" />
     <Analyzer Include="..\..\packages\SonarLint.1.7.0\analyzers\SonarLint.dll" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Integration/Persistence/ISolutionBindingSerializer.cs
+++ b/src/Integration/Persistence/ISolutionBindingSerializer.cs
@@ -8,7 +8,7 @@
 namespace SonarLint.VisualStudio.Integration.Persistence
 {
     // Test interface
-    internal interface ISolutionBinding : ILocalService
+    internal interface ISolutionBindingSerializer : ILocalService
     {
         /// <summary>
         /// Retrieves solution binding information

--- a/src/Integration/Persistence/SolutionBindingSerializer.cs
+++ b/src/Integration/Persistence/SolutionBindingSerializer.cs
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------
-// <copyright file="SolutionBinding.cs" company="SonarSource SA and Microsoft Corporation">
+// <copyright file="SolutionBindingSerializer.cs" company="SonarSource SA and Microsoft Corporation">
 //   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
 //   Licensed under the MIT License. See License.txt in the project root for license information.
 // </copyright>
@@ -15,21 +15,20 @@ using System.IO;
 
 namespace SonarLint.VisualStudio.Integration.Persistence
 {
-    internal class SolutionBinding : ISolutionBinding
+    internal class SolutionBindingSerializer : ISolutionBindingSerializer
     {
         private readonly IServiceProvider serviceProvider;
         private readonly ICredentialStore credentialStore;
-        private readonly IProjectSystemHelper projectSystemHelper;
 
         public const string SonarQubeSolutionBindingConfigurationFileName = "SolutionBinding.sqconfig";
         public const string StoreNamespace = "SonarLint.VisualStudio.Integration";
 
-        public SolutionBinding(IServiceProvider serviceProvider)
+        public SolutionBindingSerializer(IServiceProvider serviceProvider)
             :this(serviceProvider, new SecretStore(StoreNamespace))
         {
         }
 
-        internal /*for testing purposes*/ SolutionBinding(IServiceProvider serviceProvider, ICredentialStore store)
+        internal /*for testing purposes*/ SolutionBindingSerializer(IServiceProvider serviceProvider, ICredentialStore store)
         {
             if (serviceProvider == null)
             {
@@ -43,9 +42,6 @@ namespace SonarLint.VisualStudio.Integration.Persistence
 
             this.serviceProvider = serviceProvider;
             this.credentialStore = store;
-
-            this.projectSystemHelper = this.serviceProvider.GetService<IProjectSystemHelper>();
-            this.projectSystemHelper.AssertLocalServiceIsNotNull();
         }
 
         internal ICredentialStore Store
@@ -98,14 +94,17 @@ namespace SonarLint.VisualStudio.Integration.Persistence
         {
             Debug.Assert(!string.IsNullOrWhiteSpace(configFile), "Invalid configuration file");
 
-            Project solutionItemsProject = this.projectSystemHelper.GetSolutionItemsProject();
+            var projectSystemHelper = this.serviceProvider.GetService<IProjectSystemHelper>();
+            projectSystemHelper.AssertLocalServiceIsNotNull();
+
+            Project solutionItemsProject = projectSystemHelper.GetSolutionItemsProject();
             if (solutionItemsProject == null)
             {
                 Debug.Fail("Could not find the solution items project");
             }
             else
             {
-                this.projectSystemHelper.AddFileToProject(solutionItemsProject, configFile);
+                projectSystemHelper.AddFileToProject(solutionItemsProject, configFile);
             }
         }
 

--- a/src/Integration/ProfileConflicts/ConflictsManager.cs
+++ b/src/Integration/ProfileConflicts/ConflictsManager.cs
@@ -88,7 +88,7 @@ namespace SonarLint.VisualStudio.Integration.ProfileConflicts
 
         private RuleSetInformation[] GetAggregatedSolutionRuleSets()
         {
-            var solutionBinding = this.serviceProvider.GetService<ISolutionBinding>();
+            var solutionBinding = this.serviceProvider.GetService<ISolutionBindingSerializer>();
             solutionBinding.AssertLocalServiceIsNotNull();
 
             BoundSonarQubeProject bindingInfo = solutionBinding.ReadSolutionBinding();

--- a/src/Integration/SonarAnalyzer/ActiveSolutionBoundTracker.cs
+++ b/src/Integration/SonarAnalyzer/ActiveSolutionBoundTracker.cs
@@ -46,7 +46,7 @@ namespace SonarLint.VisualStudio.Integration.SonarAnalyzer
 
         private void CalculateSolutionBinding()
         {
-            ISolutionBinding solutionBinding = this.extensionHost.GetService<ISolutionBinding>();
+            ISolutionBindingSerializer solutionBinding = this.extensionHost.GetService<ISolutionBindingSerializer>();
             solutionBinding.AssertLocalServiceIsNotNull();
 
             BoundSonarQubeProject bindingInfo = solutionBinding.ReadSolutionBinding();

--- a/src/Integration/VsSessionHost.cs
+++ b/src/Integration/VsSessionHost.cs
@@ -30,7 +30,7 @@ namespace SonarLint.VisualStudio.Integration
         {
                 typeof(ISolutionRuleSetsInformationProvider),
                 typeof(IRuleSetSerializer),
-                typeof(ISolutionBinding),
+                typeof(ISolutionBindingSerializer),
                 typeof(IProjectSystemHelper),
                 typeof(ISourceControlledFileSystem),
                 typeof(IFileSystem),
@@ -235,7 +235,7 @@ namespace SonarLint.VisualStudio.Integration
 
         private BoundSonarQubeProject SafeReadBindingInformation()
         {
-            ISolutionBinding solutionBinding = this.GetService<ISolutionBinding>();
+            ISolutionBindingSerializer solutionBinding = this.GetService<ISolutionBindingSerializer>();
             solutionBinding.AssertLocalServiceIsNotNull();
 
             BoundSonarQubeProject bound = null;
@@ -262,7 +262,7 @@ namespace SonarLint.VisualStudio.Integration
         {
             this.localServices.Add(typeof(ISolutionRuleSetsInformationProvider), new Lazy<ILocalService>(() => new SolutionRuleSetsInformationProvider(this)));
             this.localServices.Add(typeof(IRuleSetSerializer), new Lazy<ILocalService>(() => new RuleSetSerializer()));
-            this.localServices.Add(typeof(ISolutionBinding), new Lazy<ILocalService>(() => new SolutionBinding(this)));
+            this.localServices.Add(typeof(ISolutionBindingSerializer), new Lazy<ILocalService>(() => new SolutionBindingSerializer(this)));
             this.localServices.Add(typeof(IProjectSystemHelper), new Lazy<ILocalService>(() => new ProjectSystemHelper(this)));
             this.localServices.Add(typeof(IConflictsManager), new Lazy<ILocalService>(() => new ConflictsManager(this)));
             this.localServices.Add(typeof(IRuleSetInspector), new Lazy<ILocalService>(() => new RuleSetInspector(this)));
@@ -296,7 +296,7 @@ namespace SonarLint.VisualStudio.Integration
             if (this.localServices.ContainsKey(typeof(T)))
             {
                 this.localServices[typeof(T)] = new Lazy<ILocalService>(() => instance);
-            }
+        }
         }
         #endregion
 

--- a/src/TestInfrastructure/Framework/ConfigurableSolutionBindingSerializer.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableSolutionBindingSerializer.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------
-// <copyright file="ConfigurableSolutionBinding.cs" company="SonarSource SA and Microsoft Corporation">
+// <copyright file="ConfigurableSolutionBindingSerializer.cs" company="SonarSource SA and Microsoft Corporation">
 //   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
 //   Licensed under the MIT License. See License.txt in the project root for license information.
 // </copyright>
@@ -11,18 +11,18 @@ using System;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests
 {
-    internal class ConfigurableSolutionBinding : ISolutionBinding
+    internal class ConfigurableSolutionBindingSerializer : ISolutionBindingSerializer
     {
         private int writtenFiles;
 
-        #region ISolutionBinding
-        BoundSonarQubeProject ISolutionBinding.ReadSolutionBinding()
+        #region ISolutionBindingSerializer
+        BoundSonarQubeProject ISolutionBindingSerializer.ReadSolutionBinding()
         {
             this.ReadSolutionBindingAction?.Invoke();
             return this.CurrentBinding;
         }
 
-        string ISolutionBinding.WriteSolutionBinding(BoundSonarQubeProject binding)
+        string ISolutionBindingSerializer.WriteSolutionBinding(BoundSonarQubeProject binding)
         {
             Assert.IsNotNull(binding, "Required argument");
 

--- a/src/TestInfrastructure/TestInfrastructure.csproj
+++ b/src/TestInfrastructure/TestInfrastructure.csproj
@@ -127,9 +127,9 @@
     <Compile Include="Framework\ConfigurableRuleSetConflictsController.cs" />
     <Compile Include="Framework\ConfigurableRuleSetInspector.cs" />
     <Compile Include="Framework\ConfigurableSettingsManager.cs" />
+    <Compile Include="Framework\ConfigurableSolutionBindingSerializer.cs" />
     <Compile Include="Framework\ConfigurableSolutionRuleSetsInformationProvider.cs" />
     <Compile Include="Framework\ConfigurableSolutionRuleStore.cs" />
-    <Compile Include="Framework\ConfigurableSolutionBinding.cs" />
     <Compile Include="Framework\ConfigurableSourceControlledFileSystem.cs" />
     <Compile Include="Framework\ConfigurableStateManager.cs" />
     <Compile Include="Framework\ConfigurableVsCommand.cs" />


### PR DESCRIPTION
Rename SolutionBinding to SolutionBindingSerializer (consistent with another functionally similar class), also less ambiguous.

All the changes are obvious except for one - which I'll comment inline. 

NOTE : Please look at the specific commit (6e6....) since this builds on top of an already existing PR (the first commit). Once the 1st PR is reviewed and we can check it in I'll commit and rebase this one,