### PR TITLE
[Technical] Remove non-required IDisposable objects from VSIX

### DIFF
--- a/src/Integration.Vsix.UnitTests/SonarAnalyzer/SonarAnalyzerDeactivationManagerForBoundTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarAnalyzer/SonarAnalyzerDeactivationManagerForBoundTests.cs
@@ -18,7 +18,7 @@ using System.Windows.Threading;
 namespace SonarLint.VisualStudio.Integration.UnitTests.SonarAnalyzer
 {
     [TestClass]
-    public class SonarAnalyzerDeactivationManagerForBoundTests : IDisposable
+    public class SonarAnalyzerDeactivationManagerForBoundTests
     {
         private ConfigurableServiceProvider serviceProvider;
         private ConfigurableHost host;
@@ -152,11 +152,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.SonarAnalyzer
                 this.testObject.GetIsBoundWithoutAnalyzer(
                     SonarAnalyzerDeactivationManager.GetProjectAnalyzerConflictStatus(references)),
                 "Bound solution with conflicting analyzer name should never return true");
-        }
-
-        public void Dispose()
-        {
-            this.testObject?.Dispose();
         }
     }
 }

--- a/src/Integration.Vsix/SonarAnalyzerDeactivationManager.cs
+++ b/src/Integration.Vsix/SonarAnalyzerDeactivationManager.cs
@@ -10,15 +10,15 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.LanguageServices;
 using SonarLint.Helpers;
+using SonarLint.VisualStudio.Integration.SonarAnalyzer;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using SonarLint.VisualStudio.Integration.SonarAnalyzer;
 
 namespace SonarLint.VisualStudio.Integration.Vsix
 {
-    public class SonarAnalyzerDeactivationManager : IDisposable
+    public class SonarAnalyzerDeactivationManager
     {
         internal /*for testing purposes*/ enum ProjectAnalyzerStatus
         {
@@ -122,22 +122,5 @@ namespace SonarLint.VisualStudio.Integration.Vsix
                 ? ProjectAnalyzerStatus.DifferentVersion
                 : ProjectAnalyzerStatus.SameVersion;
         }
-
-        #region IDisposable
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                this.activeSolutionBoundTracker?.Dispose();
-            }
-        }
-
-        public void Dispose()
-        {
-            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-            this.Dispose(true);
-        }
-        #endregion
     }
 }

--- a/src/Integration.Vsix/SonarLintIntegrationPackage.cs
+++ b/src/Integration.Vsix/SonarLintIntegrationPackage.cs
@@ -56,9 +56,6 @@ namespace SonarLint.VisualStudio.Integration.Vsix
             {
                 this.usageAnalyzer?.Dispose();
                 this.usageAnalyzer = null;
-
-                this.sonarAnalyzerDeactivationManager?.Dispose();
-                this.sonarAnalyzerDeactivationManager = null;
             }
         }
     }


### PR DESCRIPTION
SonarAnalyzerDeactivationManager  disposed a MEF imported service by implementing IDisposable interface and as a result the test implemented it as well (presumable in order to avoid suppressing a false positive which would be a more appropriate in this case). 
The thing is that MEF IDisposable components are managed and disposed by MEF, so we should not need all of that, hence this PR. 