### PR TITLE
[SVS-9] Add an ErrorListInfoBarController stub

### DIFF
--- a/src/Integration.UnitTests/LocalServices/SolutionBindingInformationProviderTests.cs
+++ b/src/Integration.UnitTests/LocalServices/SolutionBindingInformationProviderTests.cs
@@ -49,6 +49,25 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         }
 
         [TestMethod]
+        public void SolutionBindingInformationProvider_IsSolutionBound()
+        {
+            // Setup
+            var testSubject = new SolutionBindingInformationProvider(this.serviceProvider);
+
+            // Case 1: Not bound
+            this.bindingSerializer.CurrentBinding = null;
+
+            // Act + Verify
+            Assert.IsFalse(testSubject.IsSolutionBound());
+
+            // Case 2: Bound
+            this.bindingSerializer.CurrentBinding = new Persistence.BoundSonarQubeProject();
+
+            // Act + Verify
+            Assert.IsTrue(testSubject.IsSolutionBound());
+        }
+
+        [TestMethod]
         public void SolutionBindingInformationProvider_GetBoundProjects_SolutionNotBound()
         {
             // Setup
@@ -61,7 +80,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
             // Verify
             AssertEmptyResult(projects);
-
         }
 
         [TestMethod]
@@ -170,6 +188,22 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             // Verify
             Assert.AreSame(boundProject, projects.SingleOrDefault(), "Unexpected bound project");
             this.ruleSetSerializer.AssertAllRegisteredRuleSetsLoadedExactlyOnce();
+        }
+
+
+        [TestMethod]
+        public void SolutionBindingInformationProvider_GetUnboundProjects_SolutionNotBound()
+        {
+            // Setup
+            var testSubject = new SolutionBindingInformationProvider(this.serviceProvider);
+            this.bindingSerializer.CurrentBinding = null;
+            IEnumerable<Project> projects;
+
+            // Act
+            projects = testSubject.GetUnboundProjects();
+
+            // Verify
+            AssertEmptyResult(projects);
         }
 
         [TestMethod]

--- a/src/Integration.UnitTests/VsSessionHostTests.cs
+++ b/src/Integration.UnitTests/VsSessionHostTests.cs
@@ -11,7 +11,6 @@ using SonarLint.VisualStudio.Integration.Persistence;
 using SonarLint.VisualStudio.Integration.TeamExplorer;
 using SonarLint.VisualStudio.Integration.WPF;
 using System;
-using System.ComponentModel.Design;
 using System.Windows.Threading;
 
 namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
@@ -133,6 +132,47 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.TeamExplorer
             // Verify
             Assert.IsNull(testSubject.ActiveSection);
             Assert.IsNull(section.ViewModel.State);
+        }
+
+        [TestMethod]
+        public void VsSessionHost_ActiveSectionChangedEvent()
+        {
+            // Setup
+            VsSessionHost testSubject = this.CreateTestSubject(null);
+            ISectionController section = ConfigurableSectionController.CreateDefault();
+            ISectionController otherSection = ConfigurableSectionController.CreateDefault();
+            int changed = 0;
+            testSubject.ActiveSectionChanged += (o, e) => changed++;
+
+            // Act (1st set)
+            testSubject.SetActiveSection(section);
+
+            // Verify
+            Assert.AreEqual(1, changed, "ActiveSectionChanged event was expected to fire");
+
+            // Act (clear)
+            testSubject.ClearActiveSection();
+
+            // Verify
+            Assert.AreEqual(2, changed, "ActiveSectionChanged event was expected to fire");
+
+            // Act (2nd set)
+            testSubject.SetActiveSection(otherSection);
+
+            // Verify
+            Assert.AreEqual(3, changed, "ActiveSectionChanged event was expected to fire");
+
+            // Act (clear)
+            testSubject.ClearActiveSection();
+
+            // Verify
+            Assert.AreEqual(4, changed, "ActiveSectionChanged event was expected to fire");
+
+            // Act (clear again)
+            testSubject.ClearActiveSection();
+
+            // Verify
+            Assert.AreEqual(4, changed, "ActiveSectionChanged event was not expected to fire, since already cleared");
         }
 
         [TestMethod]

--- a/src/Integration.Vsix.UnitTests/InfoBar/InfoBarManagerTests.cs
+++ b/src/Integration.Vsix.UnitTests/InfoBar/InfoBarManagerTests.cs
@@ -69,6 +69,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
             // Act
             IInfoBar infoBarWrapper = testSubject.AttachInfoBar(windowGuid, "Hello", "world", KnownMonikers.UserWarning);
+            frame.AssertShowNoActivateCalled(1);
             bool actionClicked = false;
             bool closed = false;
             infoBarWrapper.ButtonClick += (s, e) => actionClicked = true;
@@ -110,6 +111,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             // Verify
             Assert.IsFalse(actionClicked);
             Assert.IsFalse(closed);
+            frame.AssertShowNoActivateCalled(1); // Should only be called once in all this flow
         }
 
         [TestMethod]
@@ -117,7 +119,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Setup
             Guid windowGuid = new Guid();
-            this.shell.RegisterToolWindow(windowGuid);
+            ConfigurableVsWindowFrame frame = this.shell.RegisterToolWindow(windowGuid);
             var testSubject = new InfoBarManager(this.serviceProvider);
 
             // Case 1: No service
@@ -125,12 +127,14 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
             // Act + Verify
             Assert.IsNull(testSubject.AttachInfoBar(windowGuid, "Hello", "world", default(ImageMoniker)));
+            frame.AssertShowNoActivateCalled(0);
 
             // Case 2: Service exists, no host for frame
             this.serviceProvider.RegisterService(typeof(SVsInfoBarUIFactory), new ConfigurableVsInfoBarUIFactory());
 
             // Act + Verify
             Assert.IsNull(testSubject.AttachInfoBar(windowGuid, "Hello", "world", default(ImageMoniker)));
+            frame.AssertShowNoActivateCalled(0);
         }
 
         [TestMethod]

--- a/src/Integration.Vsix.UnitTests/SonarAnalyzer/SonarAnalyzerDeactivationManagerForBoundTests.cs
+++ b/src/Integration.Vsix.UnitTests/SonarAnalyzer/SonarAnalyzerDeactivationManagerForBoundTests.cs
@@ -9,7 +9,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using SonarLint.VisualStudio.Integration.SonarAnalyzer;
 using SonarLint.VisualStudio.Integration.Vsix;
 using System;
 using System.Collections.Generic;
@@ -18,6 +17,11 @@ using System.Windows.Threading;
 namespace SonarLint.VisualStudio.Integration.UnitTests.SonarAnalyzer
 {
     [TestClass]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", 
+        "S2931:Classes with \"IDisposable\" members should implement \"IDisposable\"", 
+        Justification = "By-design. Test classes will do it part of the test clean up", 
+        Scope = "type", 
+        Target = "~T:SonarLint.VisualStudio.Integration.UnitTests.SonarAnalyzer.SonarAnalyzerDeactivationManagerForBoundTests")]
     public class SonarAnalyzerDeactivationManagerForBoundTests
     {
         private ConfigurableServiceProvider serviceProvider;
@@ -40,6 +44,12 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.SonarAnalyzer
             this.serviceProvider.RegisterService(typeof (SComponentModel), mefModel, replaceExisting: true);
 
             this.testObject = new SonarAnalyzerDeactivationManager(this.serviceProvider, new AdhocWorkspace());
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            this.activeSolutionBoundTracker.Dispose(); // be nice. and dispose
         }
 
         [TestMethod]

--- a/src/Integration.Vsix/InfoBar/InfoBarManager.cs
+++ b/src/Integration.Vsix/InfoBar/InfoBarManager.cs
@@ -174,6 +174,9 @@ namespace SonarLint.VisualStudio.Integration.Vsix.InfoBar
 
                 this.InfoBarUIElement = uiElement;
                 this.Frame = frame;
+
+                this.Frame.ShowNoActivate();
+
                 this.Advise();
             }
 

--- a/src/Integration.Vsix/SonarAnalyzerDeactivationManager.cs
+++ b/src/Integration.Vsix/SonarAnalyzerDeactivationManager.cs
@@ -10,7 +10,6 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.LanguageServices;
 using SonarLint.Helpers;
-using SonarLint.VisualStudio.Integration.SonarAnalyzer;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Integration.Vsix/Telemetry/GeneratedCode/SqmCommandFacade.cs
+++ b/src/Integration.Vsix/Telemetry/GeneratedCode/SqmCommandFacade.cs
@@ -156,6 +156,15 @@ namespace SonarLint.VisualStudio.Integration
             DEBUG_LogSqmCommandsToOutputWindow("FixConflictsCommand");
         }
 
+        /// <summary>
+        /// SQM command for UpdateBindingCommandFromErrorList.
+        /// </summary>
+        public static void UpdateBindingCommandFromErrorList()
+        {
+            RunCommand(CommandSetIdentifier, (int)SonarLintSqmCommandIds.UpdateBindingCommandFromErrorListCommandId);
+            DEBUG_LogSqmCommandsToOutputWindow("UpdateBindingCommandFromErrorList");
+        }
+
         #region Private methods
         private static void RunCommand(Guid commandGroup, int commandId)
         {

--- a/src/Integration.Vsix/Telemetry/GeneratedCode/SqmOleCommandTarget.cs
+++ b/src/Integration.Vsix/Telemetry/GeneratedCode/SqmOleCommandTarget.cs
@@ -33,6 +33,7 @@ namespace SonarLint.VisualStudio.Integration
         ToggleShowAllProjectsCommandCommandId = 0x306,
         DontWarnAgainCommandCommandId = 0x307,
         FixConflictsCommandCommandId = 0x308,
+        UpdateBindingCommandFromErrorListCommandId = 0x400,
     }
 
     /// <summary>
@@ -95,6 +96,7 @@ namespace SonarLint.VisualStudio.Integration
                     case SonarLintSqmCommandIds.ToggleShowAllProjectsCommandCommandId:
                     case SonarLintSqmCommandIds.DontWarnAgainCommandCommandId:
                     case SonarLintSqmCommandIds.FixConflictsCommandCommandId:
+                    case SonarLintSqmCommandIds.UpdateBindingCommandFromErrorListCommandId:
                     {
                         return true;
                     }

--- a/src/Integration.Vsix/Telemetry/GeneratedCode/SqmVsCommands.vsct
+++ b/src/Integration.Vsix/Telemetry/GeneratedCode/SqmVsCommands.vsct
@@ -94,6 +94,14 @@
                         <ButtonText>FixConflictsCommand</ButtonText>
                     </Strings>
                 </Button>
+  
+                <Button guid="guidCmdSet" id="UpdateBindingCommandFromErrorList" priority="0x00" type="Button">
+                    <CommandFlag>NoButtonCustomize</CommandFlag>
+                    <CommandFlag>NoKeyCustomize</CommandFlag>
+                    <Strings>
+                        <ButtonText>UpdateBindingCommandFromErrorList</ButtonText>
+                    </Strings>
+                </Button>
             </Buttons>
         </Commands>
         <Symbols>
@@ -109,6 +117,7 @@
                     <IDSymbol name="ToggleShowAllProjectsCommand" value="0x306" />
                     <IDSymbol name="DontWarnAgainCommand" value="0x307" />
                     <IDSymbol name="FixConflictsCommand" value="0x308" />
+                    <IDSymbol name="UpdateBindingCommandFromErrorList" value="0x400" />
                 </GuidSymbol>
         </Symbols>
         <!-- Add UsedCommands so that a command table merge does not remove these commands    -->
@@ -124,5 +133,6 @@
             <UsedCommand guid="guidCmdSet" id="ToggleShowAllProjectsCommand" />
             <UsedCommand guid="guidCmdSet" id="DontWarnAgainCommand" />
             <UsedCommand guid="guidCmdSet" id="FixConflictsCommand" />
+            <UsedCommand guid="guidCmdSet" id="UpdateBindingCommandFromErrorList" />
         </UsedCommands>
     </CommandTable>

--- a/src/Integration.Vsix/Telemetry/SonarLintSqmData.ttinclude
+++ b/src/Integration.Vsix/Telemetry/SonarLintSqmData.ttinclude
@@ -30,15 +30,17 @@ IEnumerable<Tuple<string, string, string>> commands = new ReadOnlyCollection <Tu
         Tuple.Create("BoundSolutionDetected",			"0x200", "SonarLint.VisualStudio was used for tech debt management"),
 
         // Commands
-        Tuple.Create("ConnectCommand",					"0x300", "SonarLint.VisualStudio ConnectCommand was called"),
-        Tuple.Create("BindCommand",						"0x301", "SonarLint.VisualStudio BindCommand was called"),
-        Tuple.Create("BrowseToUrlCommand",				"0x302", "SonarLint.VisualStudio BrowseToUrlCommand was called"),
-        Tuple.Create("BrowseToProjectDashboardCommand",	"0x303", "SonarLint.VisualStudio BrowseToProjectDashboardCommand was called"),
-        Tuple.Create("RefreshCommand",					"0x304", "SonarLint.VisualStudio RefreshCommand was called"),
-        Tuple.Create("DisconnectCommand",				"0x305", "SonarLint.VisualStudio DisconnectCommand was called"),
-        Tuple.Create("ToggleShowAllProjectsCommand",	"0x306", "SonarLint.VisualStudio ToggleShowAllProjectsCommand was called"),
-        Tuple.Create("DontWarnAgainCommand",			"0x307", "SonarLint.VisualStudio DontWarnAgainCommand was called"),
-        Tuple.Create("FixConflictsCommand",				"0x308", "SonarLint.VisualStudio FixConflictsCommand was called"),
+        Tuple.Create("ConnectCommand",						"0x300", "SonarLint.VisualStudio ConnectCommand was called"),
+        Tuple.Create("BindCommand",							"0x301", "SonarLint.VisualStudio BindCommand was called"),
+        Tuple.Create("BrowseToUrlCommand",					"0x302", "SonarLint.VisualStudio BrowseToUrlCommand was called"),
+        Tuple.Create("BrowseToProjectDashboardCommand",		"0x303", "SonarLint.VisualStudio BrowseToProjectDashboardCommand was called"),
+        Tuple.Create("RefreshCommand",						"0x304", "SonarLint.VisualStudio RefreshCommand was called"),
+        Tuple.Create("DisconnectCommand",					"0x305", "SonarLint.VisualStudio DisconnectCommand was called"),
+        Tuple.Create("ToggleShowAllProjectsCommand",		"0x306", "SonarLint.VisualStudio ToggleShowAllProjectsCommand was called"),
+        Tuple.Create("DontWarnAgainCommand",				"0x307", "SonarLint.VisualStudio DontWarnAgainCommand was called"),
+        Tuple.Create("FixConflictsCommand",					"0x308", "SonarLint.VisualStudio FixConflictsCommand was called"),
+        // Info bar
+        Tuple.Create("UpdateBindingCommandFromErrorList",	"0x400", "SonarLint.VisualStudio ErrorList info bar Update button was clicked"),
     }
 );
 #>

--- a/src/Integration/Integration.csproj
+++ b/src/Integration/Integration.csproj
@@ -112,6 +112,8 @@
   <ItemGroup>
     <Compile Include="Binding\BindingController.cs" />
     <Compile Include="Binding\IBindingOperation.cs" />
+    <Compile Include="LocalServices\IErrorListInfoBarController.cs" />
+    <Compile Include="LocalServices\ErrorListInfoBarController.cs" />
     <Compile Include="LocalServices\ISolutionBindingInformationProvider.cs" />
     <Compile Include="LocalServices\SolutionBindingInformationProvider.cs" />
     <Compile Include="MefServices\IInfoBar.cs" />

--- a/src/Integration/LocalServices/ErrorListInfoBarController.cs
+++ b/src/Integration/LocalServices/ErrorListInfoBarController.cs
@@ -1,0 +1,42 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ErrorListInfoBarController.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+
+namespace SonarLint.VisualStudio.Integration
+{
+    internal class ErrorListInfoBarController : IErrorListInfoBarController
+    {
+        private readonly IHost host;
+
+        public ErrorListInfoBarController(IHost host)
+        {
+            if (host == null)
+            {
+                throw new ArgumentNullException(nameof(host));
+            }
+
+            this.host = host;
+        }
+
+        #region IErrorListInfoBarController
+        public void Reset()
+        {
+            // TBD
+        }
+
+        public void Refresh()
+        {
+            // TBD
+        }
+        #endregion
+
+        #region Non-public API
+
+        #endregion
+    }
+}

--- a/src/Integration/LocalServices/IErrorListInfoBarController.cs
+++ b/src/Integration/LocalServices/IErrorListInfoBarController.cs
@@ -1,0 +1,22 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="IErrorListInfoBarController.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace SonarLint.VisualStudio.Integration
+{
+    internal interface IErrorListInfoBarController : ILocalService
+    {
+        /// <summary>
+        /// Checks whether the error list info bar needs to be displayed
+        /// </summary>
+        void Refresh();
+
+        /// <summary>
+        /// Clears the info bar, if any
+        /// </summary>
+        void Reset();
+    }
+}

--- a/src/Integration/LocalServices/ISolutionBindingInformationProvider.cs
+++ b/src/Integration/LocalServices/ISolutionBindingInformationProvider.cs
@@ -32,5 +32,10 @@ namespace SonarLint.VisualStudio.Integration
         /// <seealso cref="IProjectSystemHelper.GetFilteredSolutionProjects"/></remarks>
         /// <returns>Will always return an instance, never a null</returns>
         IEnumerable<Project> GetUnboundProjects();
+
+        /// <summary>
+        /// Returns whether the solution is bound to SonarQube
+        /// </summary>
+        bool IsSolutionBound();
     }
 }

--- a/src/Integration/LocalServices/SolutionBindingInformationProvider.cs
+++ b/src/Integration/LocalServices/SolutionBindingInformationProvider.cs
@@ -43,7 +43,7 @@ namespace SonarLint.VisualStudio.Integration
 
         public IEnumerable<Project> GetUnboundProjects()
         {
-            return this.GetUnBoundProject(this.GetSolutionBinding());
+            return this.GetUnboundProjects(this.GetSolutionBinding());
         }
         #endregion
 
@@ -56,7 +56,7 @@ namespace SonarLint.VisualStudio.Integration
             return bindingSerializer.ReadSolutionBinding();
         }
 
-        private IEnumerable<Project> GetUnBoundProject(BoundSonarQubeProject binding)
+        private IEnumerable<Project> GetUnboundProjects(BoundSonarQubeProject binding)
         {
             if (binding == null)
             {
@@ -66,6 +66,7 @@ namespace SonarLint.VisualStudio.Integration
             var projectSystem = this.serviceProvider.GetService<IProjectSystemHelper>();
             projectSystem.AssertLocalServiceIsNotNull();
 
+            // Reuse the binding information passed in to avoid reading it more than once
             return projectSystem.GetFilteredSolutionProjects().Except(this.GetBoundProjects(binding));
         }
 
@@ -87,6 +88,8 @@ namespace SonarLint.VisualStudio.Integration
 
             // Note: we will still may end up analyzing the same project rule set
             // but that should in marginal since it will be already loaded into memory
+
+            // Reuse the binding information passed in to avoid reading it more than once
             return projectSystem.GetFilteredSolutionProjects()
                 .Where(p => this.IsFullyBoundProject(cache, binding, p));
         }

--- a/src/Integration/MefServices/ActiveSolutionBoundTracker.cs
+++ b/src/Integration/MefServices/ActiveSolutionBoundTracker.cs
@@ -41,28 +41,28 @@ namespace SonarLint.VisualStudio.Integration
             this.errorListInfoBarController = this.extensionHost.GetService<IErrorListInfoBarController>();
             this.errorListInfoBarController.AssertLocalServiceIsNotNull();
 
-            this.CalcualteSolutionBinding();
+            this.CalculateSolutionBinding();
         }
 
         public bool IsActiveSolutionBound { get; private set; } = false;
 
         private void OnActiveSolutionChanged(object sender, EventArgs e)
         {
-            this.CalcualteSolutionBinding();
+            this.CalculateSolutionBinding();
         }
 
         private void OnBindingStateChanged(object sender, EventArgs e)
         {
-            this.CalculatCurrentBinding();
+            this.CalculateCurrentBinding();
         }
 
-        private void CalcualteSolutionBinding()
+        private void CalculateSolutionBinding()
         {
-            this.CalculatCurrentBinding();
+            this.CalculateCurrentBinding();
             this.errorListInfoBarController.Refresh();
         }
 
-        private void CalculatCurrentBinding()
+        private void CalculateCurrentBinding()
         {
             ISolutionBindingSerializer solutionBinding = this.extensionHost.GetService<ISolutionBindingSerializer>();
             solutionBinding.AssertLocalServiceIsNotNull();

--- a/src/Integration/MefServices/IActiveSolutionBoundTracker.cs
+++ b/src/Integration/MefServices/IActiveSolutionBoundTracker.cs
@@ -7,7 +7,7 @@
 
 using System;
 
-namespace SonarLint.VisualStudio.Integration.SonarAnalyzer
+namespace SonarLint.VisualStudio.Integration
 {
     /// <summary>
     /// Allows checking if the current Visual Studio solution is bound to a SonarQube project or not

--- a/src/Integration/MefServices/IHost.cs
+++ b/src/Integration/MefServices/IHost.cs
@@ -41,6 +41,11 @@ namespace SonarLint.VisualStudio.Integration
         void SetActiveSection(ISectionController section);
 
         /// <summary>
+        /// Change event when the <see cref="ActiveSection"/> changed
+        /// </summary>
+        event EventHandler ActiveSectionChanged;
+
+        /// <summary>
         /// Clears the <see cref="ActiveSection"/>
         /// </summary>
         void ClearActiveSection();

--- a/src/Integration/TelemetryEvent.cs
+++ b/src/Integration/TelemetryEvent.cs
@@ -21,6 +21,9 @@ namespace SonarLint.VisualStudio.Integration
         DisconnectCommandCommandCalled,
         ToggleShowAllProjectsCommandCommandCalled,
         DontWarnAgainCommandCalled,
-        FixConflictsCommandCalled
+        FixConflictsCommandCalled,
+
+        // Info bar
+        InfoBarUpdateBindingFromErrorList
     }
 }

--- a/src/TestInfrastructure/Framework/ConfigurableActiveSolutionBoundTracker.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableActiveSolutionBoundTracker.cs
@@ -5,8 +5,6 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-using SonarLint.VisualStudio.Integration.SonarAnalyzer;
-
 namespace SonarLint.VisualStudio.Integration.UnitTests
 {
     public class ConfigurableActiveSolutionBoundTracker : IActiveSolutionBoundTracker
@@ -15,6 +13,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
         public void Dispose()
         {
+            // Default interface implementation
         }
     }
 }

--- a/src/TestInfrastructure/Framework/ConfigurableErrorListInfoBarController.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableErrorListInfoBarController.cs
@@ -1,0 +1,41 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ConfigurableErrorListInfoBarController.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests
+{
+    internal class ConfigurableErrorListInfoBarController : IErrorListInfoBarController
+    {
+        private int refreshCalled;
+        private int resetCalled;
+
+        #region IErrorListInfoBarController
+        void IErrorListInfoBarController.Refresh()
+        {
+            this.refreshCalled++;
+        }
+
+        void IErrorListInfoBarController.Reset()
+        {
+            this.resetCalled++;
+        }
+        #endregion
+
+        #region Test helpers
+        public void AssertRefreshCalled(int expectedNumberOfTimes)
+        {
+            Assert.AreEqual(expectedNumberOfTimes, this.refreshCalled, $"{nameof(IErrorListInfoBarController.Refresh)} called unexpected number of times");
+        }
+
+        public void AssertResetCalled(int expectedNumberOfTimes)
+        {
+            Assert.AreEqual(expectedNumberOfTimes, this.resetCalled, $"{nameof(IErrorListInfoBarController.Reset)} called unexpected number of times");
+        }
+        #endregion
+    }
+}

--- a/src/TestInfrastructure/Framework/ConfigurableHost.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableHost.cs
@@ -31,6 +31,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             this.VisualStateManager = new ConfigurableStateManager { Host = this };
         }
 
+        #region IHost
+
+        public event EventHandler ActiveSectionChanged;
+
         public ISectionController ActiveSection
         {
             get;
@@ -82,5 +86,13 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             // Simulate product code
             this.VisualStateManager.SyncCommandFromActiveSection();
         }
+        #endregion
+
+        #region Test helpers
+        public void SimulateActiveSectionChanged()
+        {
+            this.ActiveSectionChanged?.Invoke(this, EventArgs.Empty);
+        }
+        #endregion
     }
 }

--- a/src/TestInfrastructure/Framework/ConfigurableVsWindowFrame.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableVsWindowFrame.cs
@@ -7,6 +7,7 @@
 
 using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 
@@ -15,6 +16,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
     public class ConfigurableVsWindowFrame : IVsWindowFrame
     {
         private readonly Dictionary<int, object> properties = new Dictionary<int, object>();
+        private int showNoActivateCalled;
 
         #region IVsWindowFrame
         int IVsWindowFrame.CloseFrame(uint grfSaveOptions)
@@ -84,6 +86,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
         int IVsWindowFrame.ShowNoActivate()
         {
+            this.showNoActivateCalled++;
             return VSConstants.S_OK;
         }
         #endregion
@@ -92,6 +95,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         public void RegisterProperty(int propertyId, object value)
         {
             this.properties[propertyId] = value;
+        }
+
+        public void AssertShowNoActivateCalled(int expectedNumberOfTimes)
+        {
+            Assert.AreEqual(expectedNumberOfTimes, this.showNoActivateCalled, "ShowNoActivate called unexpected number of times");
         }
         #endregion
     }

--- a/src/TestInfrastructure/TestInfrastructure.csproj
+++ b/src/TestInfrastructure/TestInfrastructure.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Framework\ConfigurableActiveSolutionBoundTracker.cs" />
     <Compile Include="Framework\ConfigurableBindingOperation.cs" />
     <Compile Include="Framework\ConfigurableConflictsManager.cs" />
+    <Compile Include="Framework\ConfigurableErrorListInfoBarController.cs" />
     <Compile Include="Framework\ConfigurableFileSystem.cs" />
     <Compile Include="Framework\ConfigurableHost.cs" />
     <Compile Include="Framework\ConfigurableIntegrationSettings.cs" />


### PR DESCRIPTION
ErrorListInfoBarController is complex enough to be reviewed by itself. So i split the PR into two parts - this part focuses on integration and the next PR will focus just on ErrorListInfoBarController which is responsible to call the various services and show the info bar when needed.

1. Added a stub for ErrorListInfoBarController 
2. Integrated it into the extension (the methods don't do anything at this point)
3. Added tests
4. Modified and tested other bits of the existing code which I'll be using in the non-stub version of ErrorListInfoBarController.