### PR TITLE
[SVS-81] Provide information which projects excluded from binding

### DIFF
--- a/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
+++ b/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
@@ -321,8 +321,6 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             CollectionAssert.AreEquivalent(expectedLanguages, actualLanguages.ToArray(), "Unexpected languages for binding projects");
         }
 
-        
-
         [TestMethod]
         public void BindingWorkflow_DiscoverProjects_AddsMatchingProjectsToBinding()
         {
@@ -347,6 +345,33 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             // Verify
             CollectionAssert.AreEqual(matchingProjects, testSubject.BindingProjects.ToArray(), "Unexpected projects selected for binding");
             progressEvents.AssertProgressMessages(Strings.DiscoveringSolutionProjectsProgressMessage);
+        }
+
+        [TestMethod]
+        public void BindingWorkflow_DiscoverProjects_OutputsExcludedProjects()
+        {
+            // Setup
+            ThreadHelper.SetCurrentThreadAsUIThread();
+            var controller = new ConfigurableProgressController();
+            var progressEvents = new ConfigurableProgressStepExecutionEvents();
+
+            List<Project> projects = new List<Project>();
+            for (int i = 0; i < 4; i++)
+            {
+                projects.Add(new ProjectMock($"cs{i}.csproj"));
+            }
+
+            this.projectSystemHelper.FilteredProjects = projects.Take(2);
+            this.projectSystemHelper.Projects = projects;
+
+            var testSubject = this.CreateTestSubject();
+
+            // Act
+            testSubject.DiscoverProjects(controller, progressEvents);
+
+            // Verify
+            this.outputWindowPane.AssertOutputStrings(1);
+            this.outputWindowPane.AssertMessageContainsAllWordsCaseSensitive(0, new[] { projects[2].UniqueName, projects[3].UniqueName });
         }
 
         [TestMethod]

--- a/src/Integration/Binding/BindingWorkflow.cs
+++ b/src/Integration/Binding/BindingWorkflow.cs
@@ -359,6 +359,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
             StringBuilder output = new StringBuilder();
             output.AppendLine(Strings.FilteredOutProjectFromBindingHeader);
             projects.ForEach(p => output.AppendFormat(Strings.FilteredOutProjectFormat, p.UniqueName).AppendLine());
+            output.AppendLine(Strings.FilteredOutProjectFromBindingEnding);
             VsShellUtils.WriteToGeneralOutputPane(this.host, output.ToString());
         }
         #endregion

--- a/src/Integration/Resources/Strings.Designer.cs
+++ b/src/Integration/Resources/Strings.Designer.cs
@@ -495,7 +495,16 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The following projects have been marked as excluded, are not currently supported or excluded according to SonarQube specification:.
+        ///   Looks up a localized string similar to You can change the exclusion options via the SonarLint project-level context menu i.e. Solution Explorer -&gt; Select project(s).
+        /// </summary>
+        public static string FilteredOutProjectFromBindingEnding {
+            get {
+                return ResourceManager.GetString("FilteredOutProjectFromBindingEnding", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The following projects are either not currently supported, excluded according to server specifications, or have been explicitly marked as excluded:.
         /// </summary>
         public static string FilteredOutProjectFromBindingHeader {
             get {

--- a/src/Integration/Resources/Strings.Designer.cs
+++ b/src/Integration/Resources/Strings.Designer.cs
@@ -486,6 +486,24 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to * {0}.
+        /// </summary>
+        public static string FilteredOutProjectFormat {
+            get {
+                return ResourceManager.GetString("FilteredOutProjectFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The following projects have been marked as excluded, are not currently supported or excluded according to SonarQube specification:.
+        /// </summary>
+        public static string FilteredOutProjectFromBindingHeader {
+            get {
+                return ResourceManager.GetString("FilteredOutProjectFromBindingHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Not all NuGet packages were installed. Please see output above for more information..
         /// </summary>
         public static string FinishedSolutionBindingWorkflowNotAllPackagesInstalled {

--- a/src/Integration/Resources/Strings.resx
+++ b/src/Integration/Resources/Strings.resx
@@ -553,7 +553,11 @@ This is the general format to use when writing errors to output window or when t
 {0} Unique project name</comment>
   </data>
   <data name="FilteredOutProjectFromBindingHeader" xml:space="preserve">
-    <value>The following projects have been marked as excluded, are not currently supported or excluded according to SonarQube specification:</value>
+    <value>The following projects are either not currently supported, excluded according to server specifications, or have been explicitly marked as excluded:</value>
+    <comment>Output window message</comment>
+  </data>
+  <data name="FilteredOutProjectFromBindingEnding" xml:space="preserve">
+    <value>You can change the exclusion options via the SonarLint project-level context menu i.e. Solution Explorer -&gt; Select project(s)</value>
     <comment>Output window message</comment>
   </data>
   <data name="UnknownLanguageName" xml:space="preserve">

--- a/src/Integration/Resources/Strings.resx
+++ b/src/Integration/Resources/Strings.resx
@@ -547,6 +547,15 @@ This is the general format to use when writing errors to output window or when t
   <data name="SolutionIsClosed" xml:space="preserve">
     <value>The operation requires an open solution.</value>
   </data>
+  <data name="FilteredOutProjectFormat" xml:space="preserve">
+    <value>* {0}</value>
+    <comment>Output window message
+{0} Unique project name</comment>
+  </data>
+  <data name="FilteredOutProjectFromBindingHeader" xml:space="preserve">
+    <value>The following projects have been marked as excluded, are not currently supported or excluded according to SonarQube specification:</value>
+    <comment>Output window message</comment>
+  </data>
   <data name="UnknownLanguageName" xml:space="preserve">
     <value>Unknown</value>
     <comment>Name of any unknown languages</comment>


### PR DESCRIPTION
The output is less detailed as proposed in SVS-81, but has enough information to understand which project were excluded/not supported etc.