### PR TITLE
[Techincal] [SVS-9] SonarQubeServiceWrapper is stateless and we can clearly know when the service call failed

### DIFF
--- a/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
+++ b/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
@@ -59,8 +59,13 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         [TestMethod]
         public void BindingWorkflow_ArgChecks()
         {
-            Exceptions.Expect<ArgumentNullException>(() => new BindingWorkflow(null, new ProjectInformation()));
-            Exceptions.Expect<ArgumentNullException>(() => new BindingWorkflow(new ConfigurableHost(), null));
+            var validConnection = new ConnectionInformation(new Uri("http://server"));
+            var validProjectInfo = new ProjectInformation();
+            var validHost = new ConfigurableHost();
+
+            Exceptions.Expect<ArgumentNullException>(() => new BindingWorkflow(null, validConnection, validProjectInfo));
+            Exceptions.Expect<ArgumentNullException>(() => new BindingWorkflow(validHost, null, validProjectInfo));
+            Exceptions.Expect<ArgumentNullException>(() => new BindingWorkflow(validHost, validConnection, null));
         }
 
         [TestMethod]
@@ -402,11 +407,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         private BindingWorkflow CreateTestSubject(ProjectInformation projectInfo = null)
         {
             var host = new ConfigurableHost(this.serviceProvider, Dispatcher.CurrentDispatcher);
-            this.sonarQubeService.SetConnection(new Uri("http://connected"));
+            ConnectionInformation connected = new ConnectionInformation(new Uri("http://connected"));
             host.SonarQubeService = this.sonarQubeService;
             var useProjectInfo = projectInfo ?? new ProjectInformation { Key = "key" };
-
-            return new BindingWorkflow(host, useProjectInfo);
+            return new BindingWorkflow(host, connected, useProjectInfo);
         }
 
         private ConfigurablePackageInstaller PrepareInstallPackagesTest(BindingWorkflow testSubject, IEnumerable<PackageName> nugetPackages, params Project[] projects)

--- a/src/Integration.UnitTests/Connection/ConnectionWorkflowTests.cs
+++ b/src/Integration.UnitTests/Connection/ConnectionWorkflowTests.cs
@@ -183,10 +183,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
             var controller = new ConfigurableProgressController();
             var progressEvents = new ConfigurableProgressStepExecutionEvents();
             var expectedExpression = ServerProperty.TestProjectRegexDefaultValue;
-
-            ConnectionWorkflow testSubject = new ConnectionWorkflow(this.host, new RelayCommand(AssertIfCalled));
-            var connectionInfo = new ConnectionInformation(new Uri("http://server"));
-            testSubject.ConnectedServer = connectionInfo;
+            ConnectionWorkflow testSubject = SetTestSubjectWithConnectedServer();
 
             // Sanity
             Assert.IsFalse(this.sonarQubeService.ServerProperties.Any(x => x.Key != ServerProperty.TestProjectRegexKey), "Test project regex property should not be set");
@@ -213,9 +210,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
                 Value = expectedExpression
             });
 
-            ConnectionWorkflow testSubject = new ConnectionWorkflow(this.host, new RelayCommand(AssertIfCalled));
-            var connectionInfo = new ConnectionInformation(new Uri("http://server"));
-            testSubject.ConnectedServer = connectionInfo;
+            ConnectionWorkflow testSubject = SetTestSubjectWithConnectedServer();
 
             // Act
             testSubject.DownloadServiceParameters(controller, CancellationToken.None, progressEvents);
@@ -240,9 +235,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
                 Value = badExpression
             });
 
-            ConnectionWorkflow testSubject = new ConnectionWorkflow(this.host, new RelayCommand(AssertIfCalled));
-            var connectionInfo = new ConnectionInformation(new Uri("http://server"));
-            testSubject.ConnectedServer = connectionInfo;
+            ConnectionWorkflow testSubject = SetTestSubjectWithConnectedServer();
 
             // Act
             testSubject.DownloadServiceParameters(controller, CancellationToken.None, progressEvents);
@@ -260,9 +253,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
             var controller = new ConfigurableProgressController();
             var progressEvents = new ConfigurableProgressStepExecutionEvents();
 
-            ConnectionWorkflow testSubject = new ConnectionWorkflow(this.host, new RelayCommand(AssertIfCalled));
-            var connectionInfo = new ConnectionInformation(new Uri("http://server"));
-            testSubject.ConnectedServer = connectionInfo;
+            ConnectionWorkflow testSubject = SetTestSubjectWithConnectedServer();
 
             var cts = new CancellationTokenSource();
             cts.Cancel();
@@ -282,6 +273,13 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Connection
             Assert.Fail("Command not expected to be called");
         }
 
+        private ConnectionWorkflow SetTestSubjectWithConnectedServer()
+        {
+            ConnectionWorkflow testSubject = new ConnectionWorkflow(this.host, new RelayCommand(AssertIfCalled));
+            var connectionInfo = new ConnectionInformation(new Uri("http://server"));
+            testSubject.ConnectedServer = connectionInfo;
+            return testSubject;
+        }
         #endregion
     }
 }

--- a/src/Integration.UnitTests/SanityTests.cs
+++ b/src/Integration.UnitTests/SanityTests.cs
@@ -72,7 +72,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             this.outputWindowPane.AssertOutputStrings(0);
         }
 
-        private static bool RetryAction(Func<bool> action, string description, int maxAttempts = 3)
+        private static void RetryAction(Func<bool> action, string description, int maxAttempts = 3)
         {
             for (int attempt = 0; attempt < maxAttempts; attempt++)
             {
@@ -82,12 +82,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
                 }
                 else
                 { 
-                    return true;
+                    return;
                 }
             }
 
             Assert.Fail("Failed executing the action (with retries): {0}", description);
-            return false;
         }
     }
 }

--- a/src/Integration.UnitTests/SanityTests.cs
+++ b/src/Integration.UnitTests/SanityTests.cs
@@ -26,10 +26,13 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         public void TestInitialize()
         {
             this.serviceProvider = new ConfigurableServiceProvider();
-            this.serviceProvider.RegisterService(typeof(SVsGeneralOutputWindowPane), this.outputWindowPane = new ConfigurableVsGeneralOutputWindowPane());
+            this.outputWindowPane = new ConfigurableVsGeneralOutputWindowPane();
+            this.serviceProvider.RegisterService(typeof(SVsGeneralOutputWindowPane), this.outputWindowPane);
+
+            this.logger = new ConfigurableTelemetryLogger();
             this.serviceProvider.RegisterService(typeof(SComponentModel),
                 ConfigurableComponentModel.CreateWithExports(
-                    MefTestHelpers.CreateExport<ITelemetryLogger>(this.logger = new ConfigurableTelemetryLogger())));
+                    MefTestHelpers.CreateExport<ITelemetryLogger>(this.logger)));
         }
 
         [TestCleanup]
@@ -49,15 +52,19 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             // Setup the service used to interact with SQ
             var s = new SonarQubeServiceWrapper(this.serviceProvider);
+            var connection = new ConnectionInformation(new Uri("http://nemo.sonarqube.org"));
 
             // Step 1: Connect anonymously
-            var projects = RetryAction(() => s.Connect(new ConnectionInformation(new Uri("http://nemo.sonarqube.org")), CancellationToken.None),
+            ProjectInformation[] projects = null;
+
+            RetryAction(() => s.TryGetProjects(connection, CancellationToken.None, out projects),
                                         "Get projects from SonarQube server");
-            Assert.AreNotEqual(0, projects.Count(), "No projects were returned");
+            Assert.AreNotEqual(0, projects.Length, "No projects were returned");
 
             // Step 2: Get quality profile export for the first project
             var project = projects.FirstOrDefault();
-            var export = RetryAction(() => s.GetExportProfile(project, SonarQubeServiceWrapper.CSharpLanguage, CancellationToken.None),
+            RoslynExportProfile export = null;
+            RetryAction(() => s.TryGetExportProfile(connection, project, SonarQubeServiceWrapper.CSharpLanguage, CancellationToken.None, out export),
                                         "Get quality profile export from SonarQube server");
             Assert.IsNotNull(export, "No quality profile export was returned");
 
@@ -65,24 +72,22 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             this.outputWindowPane.AssertOutputStrings(0);
         }
 
-        private static T RetryAction<T>(Func<T> action, string description, int maxAttempts = 3)
-            where T: class
+        private static bool RetryAction(Func<bool> action, string description, int maxAttempts = 3)
         {
             for (int attempt = 0; attempt < maxAttempts; attempt++)
             {
-                T value = action();
-                if (value == null)
+                if (!action())
                 {
                     Thread.Sleep(100);
                 }
                 else
                 { 
-                    return value;
+                    return true;
                 }
             }
 
             Assert.Fail("Failed executing the action (with retries): {0}", description);
-            return null;
+            return false;
         }
     }
 }

--- a/src/Integration.UnitTests/State/StateManagerTests.cs
+++ b/src/Integration.UnitTests/State/StateManagerTests.cs
@@ -329,6 +329,87 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.State
             // Verify
             Assert.AreEqual(2, countOnBindingStateChangeFired);
         }
+
+        [TestMethod]
+        public void StateManager_IsConnected()
+        {
+            // Setup
+            ConfigurableHost host = new ConfigurableHost();
+            StateManager testSubject = this.CreateTestSubject(host);
+
+            // Sanity
+            Assert.IsFalse(testSubject.IsConnected);
+
+            // Act (connect)
+            testSubject.SetProjects(new ConnectionInformation(new Uri("http://qwerty")), new ProjectInformation[0]);
+
+            // Verify
+            Assert.IsTrue(testSubject.IsConnected);
+
+            // Act (disconnect)
+            testSubject.SetProjects(new ConnectionInformation(new Uri("http://qwerty")), null);
+
+            // Verify
+            Assert.IsFalse(testSubject.IsConnected);
+        }
+
+        [TestMethod]
+        public void StateManager_GetConnectedServers()
+        {
+            // Setup
+            ConfigurableHost host = new ConfigurableHost();
+            StateManager testSubject = this.CreateTestSubject(host);
+            var connection1 = new ConnectionInformation(new Uri("http://conn1"));
+            var connection2 = new ConnectionInformation(new Uri("http://conn2"));
+
+            // Sanity
+            Assert.IsFalse(testSubject.GetConnectedServers().Any());
+
+            // Act (connect)
+            testSubject.SetProjects(connection1, new ProjectInformation[0]);
+
+            // Verify
+            CollectionAssert.AreEquivalent(new[] { connection1 } , testSubject.GetConnectedServers().ToArray());
+
+            // Act (connect another one)
+            testSubject.SetProjects(connection2, new ProjectInformation[0]);
+
+            // Verify
+            CollectionAssert.AreEquivalent(new[] { connection1, connection2 }, testSubject.GetConnectedServers().ToArray());
+
+            // Act (disconnect)
+            testSubject.SetProjects(connection1, null);
+            testSubject.SetProjects(connection2, null);
+
+            // Verify
+            Assert.IsFalse(testSubject.GetConnectedServers().Any());
+            Assert.IsTrue(connection1.IsDisposed, "Leaking connections?");
+            Assert.IsTrue(connection2.IsDisposed, "Leaking connections?");
+        }
+
+        [TestMethod]
+        public void StateManager_GetConnectedServer()
+        {
+            // Setup
+            const string SharedKey = "Key"; // The key is the same for all projects on purpose
+            ConfigurableHost host = new ConfigurableHost();
+            StateManager testSubject = this.CreateTestSubject(host);
+            var connection1 = new ConnectionInformation(new Uri("http://conn1"));
+            var project1 = new ProjectInformation { Key = SharedKey };
+            var connection2 = new ConnectionInformation(new Uri("http://conn2"));
+            var project2 = new ProjectInformation { Key = SharedKey };
+            testSubject.SetProjects(connection1, new ProjectInformation[] { project1 });
+            testSubject.SetProjects(connection2, new ProjectInformation[] { project2 });
+
+            // Case 1: Exists
+            // Act+Verify
+            Assert.AreEqual(connection1, testSubject.GetConnectedServer(project1));
+            Assert.AreEqual(connection2, testSubject.GetConnectedServer(project2));
+
+            // Case 2: Doesn't exist
+            // Act+Verify
+            Assert.IsNull(testSubject.GetConnectedServer(new ProjectInformation { Key = SharedKey }));
+        }
         #endregion
 
         #region Helpers

--- a/src/Integration.UnitTests/State/StateManagerTests.cs
+++ b/src/Integration.UnitTests/State/StateManagerTests.cs
@@ -299,6 +299,14 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.State
             // Verify
             Assert.IsFalse(section.ViewModel.IsBusy);
             Assert.IsFalse(testSubject.ManagedState.IsBusy);
+
+            // Dispose (should stop updated the view model)
+            testSubject.Dispose();
+            testSubject.IsBusy = true;
+
+            // Verify
+            Assert.IsFalse(section.ViewModel.IsBusy);
+            Assert.IsTrue(testSubject.ManagedState.IsBusy);
         }
 
         [TestMethod]
@@ -385,6 +393,22 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.State
             Assert.IsFalse(testSubject.GetConnectedServers().Any());
             Assert.IsTrue(connection1.IsDisposed, "Leaking connections?");
             Assert.IsTrue(connection2.IsDisposed, "Leaking connections?");
+        }
+
+        [TestMethod]
+        public void StateManager_Dispose()
+        {
+            // Setup
+            ConfigurableHost host = new ConfigurableHost();
+            StateManager testSubject = this.CreateTestSubject(host);
+            var connection1 = new ConnectionInformation(new Uri("http://conn1"));
+            testSubject.SetProjects(connection1, new ProjectInformation[0]);
+
+            // Act
+            testSubject.Dispose();
+
+            // Verify
+            Assert.IsTrue(connection1.IsDisposed, "Leaking connections?");
         }
 
         [TestMethod]

--- a/src/Integration/Binding/BindingController.cs
+++ b/src/Integration/Binding/BindingController.cs
@@ -95,7 +95,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
         private bool OnBindStatus(ProjectInformation projectInformation)
         {
             return projectInformation != null
-                && this.host.SonarQubeService.CurrentConnection != null
+                && this.host.VisualStateManager.IsConnected
                 && !this.host.VisualStateManager.IsBusy
                 && VsShellUtils.IsSolutionExistsAndFullyLoaded()
                 && VsShellUtils.IsSolutionExistsAndNotBuildingAndNotDebugging()
@@ -117,7 +117,10 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
         void IBindingWorkflowExecutor.BindProject(ProjectInformation projectInformation)
         {
-            BindingWorkflow workflowExecutor = new BindingWorkflow(this.host, projectInformation);
+            ConnectionInformation connection = this.host.VisualStateManager.GetConnectedServer(projectInformation);
+            Debug.Assert(connection != null, "Could not find a connected server for project: " + projectInformation?.Key);
+
+            BindingWorkflow workflowExecutor = new BindingWorkflow(this.host, connection, projectInformation);
             IProgressEvents progressEvents = workflowExecutor.Run();
             Debug.Assert(progressEvents != null, "BindingWorkflow.Run returned null");
             this.SetBindingInProgress(progressEvents, projectInformation);

--- a/src/Integration/Service/ISonarQubeServiceWrapper.cs
+++ b/src/Integration/Service/ISonarQubeServiceWrapper.cs
@@ -7,7 +7,6 @@
 
 using SonarLint.VisualStudio.Integration.Service.DataModel;
 using System;
-using System.Collections.Generic;
 using System.Threading;
 
 namespace SonarLint.VisualStudio.Integration.Service
@@ -18,29 +17,17 @@ namespace SonarLint.VisualStudio.Integration.Service
     internal interface ISonarQubeServiceWrapper
     {
         /// <summary>
-        /// When connected this property will contain the connection information, null otherwise.
+        /// Retrieves all the server projects
         /// </summary>
-        ConnectionInformation CurrentConnection { get; }
+        bool TryGetProjects(ConnectionInformation serverConnection, CancellationToken token, out ProjectInformation[] serverProjects);
 
         /// <summary>
-        /// Connects using the provided information.
-        /// If the connection is successful <see cref="CurrentConnection"/> will be set and the project information will be returned.
+        /// Retrieves all the server properties.
         /// </summary>
-        /// <param name="connectionInformation">Required connecting information</param>
-        IEnumerable<ProjectInformation> Connect(ConnectionInformation connectionInformation, CancellationToken token);
+        bool TryGetProperties(ConnectionInformation serverConnection, CancellationToken token, out ServerProperty[] properties);
 
         /// <summary>
-        /// Disconnects from the <see cref="CurrentConnection"/>
-        /// </summary>
-        void Disconnect();
-
-        /// <summary>
-        /// Retrieves all properties defined on the server specified by the <see cref="CurrentConnection"/>.
-        /// </summary>
-        IEnumerable<ServerProperty> GetProperties(CancellationToken token);
-
-        /// <summary>
-        /// Retrieves the Roslyn Quality Profile export for the specified project using the <see cref="CurrentConnection"/>.
+        /// Retrieves the server's Roslyn Quality Profile export for the specified project and language
         /// </summary>
         /// <remarks>
         /// The export contains everything required to configure the solution to match the SonarQube server analysis,
@@ -48,20 +35,18 @@ namespace SonarLint.VisualStudio.Integration.Service
         /// </remarks>
         /// <param name="project">Required project information for which to retrieve the export</param>
         /// <param name="language">Language scope. Required.</param>
-        RoslynExportProfile GetExportProfile(ProjectInformation project, string language, CancellationToken token);
+        bool TryGetExportProfile(ConnectionInformation serverConnection, ProjectInformation project, string language, CancellationToken token, out RoslynExportProfile profile);
 
         /// <summary>
-        /// Retrieves all server plugins for the given <paramref name="connectionInformation"/>.
+        /// Retrieves all server plugins
         /// </summary>
-        /// <param name="connectionInformation">Required connecting information</param>
         /// <returns>All server plugins, or null on connection failure</returns>
-        IEnumerable<ServerPlugin> GetPlugins(ConnectionInformation connectionInformation, CancellationToken token);
+        bool TryGetPlugins(ConnectionInformation serverConnection, CancellationToken token, out ServerPlugin[] plugins);
 
         /// <summary>
-        /// Generate a <see cref="Uri"/> to the dashboard for the given project on the provided <paramref name="connectionInformation"/>.
+        /// Generate a <see cref="Uri"/> to the dashboard for the given project on the provided <paramref name="serverConnection"/>.
         /// </summary>
-        /// <param name="connectionInformation">Server connection</param>
         /// <param name="project">Project to generate the <see cref="Uri"/> for</param>
-        Uri CreateProjectDashboardUrl(ConnectionInformation connectionInformation, ProjectInformation project);
+        Uri CreateProjectDashboardUrl(ConnectionInformation serverConnection, ProjectInformation project);
     }
 }

--- a/src/Integration/State/IStateManager.cs
+++ b/src/Integration/State/IStateManager.cs
@@ -36,7 +36,13 @@ namespace SonarLint.VisualStudio.Integration.State
 
         bool HasBoundProject { get; }
 
+        bool IsConnected { get; }
+
         string BoundProjectKey { get; set; }
+
+        IEnumerable<ConnectionInformation> GetConnectedServers();
+
+        ConnectionInformation GetConnectedServer(ProjectInformation project);
 
         void SetProjects(ConnectionInformation connection, IEnumerable<ProjectInformation> projects);
 

--- a/src/Integration/State/StateManager.cs
+++ b/src/Integration/State/StateManager.cs
@@ -325,6 +325,7 @@ namespace SonarLint.VisualStudio.Integration.State
                 if (disposing)
                 {
                     this.ManagedState.PropertyChanged -= this.OnStatePropertyChanged;
+                    this.DisposeConnections();
                 }
 
                 this.isDisposed = true;

--- a/src/Integration/State/StateManager.cs
+++ b/src/Integration/State/StateManager.cs
@@ -77,6 +77,25 @@ namespace SonarLint.VisualStudio.Integration.State
             }
         }
 
+        public bool IsConnected
+        {
+            get
+            {
+                return this.GetConnectedServers().Any();
+            }
+        }
+
+        public IEnumerable<ConnectionInformation> GetConnectedServers()
+        {
+            return this.ManagedState.ConnectedServers.Select(s => s.ConnectionInformation);
+        }
+
+        public ConnectionInformation GetConnectedServer(ProjectInformation project)
+        {
+            return this.ManagedState.ConnectedServers
+                .SingleOrDefault(s => s.Projects.Any(p => p.ProjectInformation == project))?.ConnectionInformation;
+        }
+
         public string BoundProjectKey { get; set; }
 
         public void SetProjects(ConnectionInformation connection, IEnumerable<ProjectInformation> projects)
@@ -150,6 +169,7 @@ namespace SonarLint.VisualStudio.Integration.State
             {
                 // Disconnected, clear all
                 this.ClearBoundProject();
+                this.DisposeConnections();
                 this.ManagedState.ConnectedServers.Clear();
             }
             else
@@ -174,6 +194,14 @@ namespace SonarLint.VisualStudio.Integration.State
                 this.SetServerProjectsVMCommands(serverViewModel);
                 this.RestoreBoundProject(serverViewModel);
             }
+        }
+
+        private void DisposeConnections()
+        {
+            this.ManagedState.ConnectedServers
+                .Select(s => s.ConnectionInformation)
+                .ToList()
+                .ForEach(c => c.Dispose());
         }
 
         private void ClearBindingErrorNotifications()

--- a/src/Integration/TeamExplorer/ProjectViewModel.cs
+++ b/src/Integration/TeamExplorer/ProjectViewModel.cs
@@ -18,6 +18,9 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
         private readonly ContextualCommandsCollection commands = new ContextualCommandsCollection();
         private bool isBound;
 
+        // Ordinal comparer should be good enough: http://docs.sonarqube.org/display/SONAR/Project+Administration#ProjectAdministration-AddingaProject
+        public static readonly StringComparer KeyComparer = StringComparer.Ordinal;
+
         public ProjectViewModel(ServerViewModel owner, ProjectInformation projectInformation)
         {
             if (owner == null)

--- a/src/Integration/TeamExplorer/SectionController.cs
+++ b/src/Integration/TeamExplorer/SectionController.cs
@@ -10,7 +10,6 @@ using Microsoft.TeamFoundation.Controls;
 using Microsoft.TeamFoundation.Controls.WPF.TeamExplorer;
 using SonarLint.VisualStudio.Integration.Progress;
 using SonarLint.VisualStudio.Integration.WPF;
-using SonarLint.VisualStudio.Progress.Controller;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
@@ -268,7 +267,9 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
 
         private bool CanDisconnect()
         {
-            return this.Host.SonarQubeService.CurrentConnection != null;
+            // We just support one at the moment, will need to pass in the server as an argument to this 
+            // command once we will want to support more than once connected server
+            return this.Host.VisualStateManager.GetConnectedServers().Any();
         }
 
         private void Disconnect()
@@ -276,10 +277,8 @@ namespace SonarLint.VisualStudio.Integration.TeamExplorer
             Debug.Assert(this.CanDisconnect());
 
             TelemetryLoggerAccessor.GetLogger(this.ServiceProvider)?.ReportEvent(TelemetryEvent.DisconnectCommandCommandCalled);
-
-            var previous = this.Host.SonarQubeService.CurrentConnection;
-            this.Host.SonarQubeService.Disconnect();
-            this.Host.VisualStateManager.SetProjects(previous, null);
+            // Disconnect all (all being one)
+            this.Host.VisualStateManager.GetConnectedServers().ToList().ForEach(c => this.Host.VisualStateManager.SetProjects(c, null));
         }
 
         private bool CanToggleShowAllProjects(ServerViewModel server)

--- a/src/TestInfrastructure/Framework/ConfigurableConnectionWorkflow.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableConnectionWorkflow.cs
@@ -37,8 +37,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             this.numberOfCalls++;
             Assert.IsNotNull(information, "Should not request to establish to a null connection");
-            Assert.AreNotSame(this.sonarQubeService.CurrentConnection, information, "Should not use the same instance to establish to connection, since it will be disposed part way through the logic");
-            this.lastConnectedProjects = this.sonarQubeService.Connect(information, CancellationToken.None)?.ToArray(); // Simulate the expected behavior in product
+            // Simulate the expected behavior in product
+            if (!this.sonarQubeService.TryGetProjects(information, CancellationToken.None, out this.lastConnectedProjects))
+            {
+                Assert.Fail("Failed to establish connection");
+            }
         }
 
         #endregion

--- a/src/TestInfrastructure/Framework/ConfigurableHost.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableHost.cs
@@ -93,6 +93,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         {
             this.ActiveSectionChanged?.Invoke(this, EventArgs.Empty);
         }
+
+        public ConfigurableStateManager TestStateManager
+        {
+            get { return (ConfigurableStateManager)this.VisualStateManager; }
+        }
         #endregion
     }
 }

--- a/src/TestInfrastructure/Framework/ConfigurableSolutionBindingInformationProvider.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableSolutionBindingInformationProvider.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="ConfigurableSolutionBindingInformationProvider.cs" company="SonarSource SA and Microsoft Corporation">
 //   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
 //   Licensed under the MIT License. See License.txt in the project root for license information.

--- a/src/TestInfrastructure/Framework/ConfigurableSolutionBindingInformationProvider.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableSolutionBindingInformationProvider.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------
 // <copyright file="ConfigurableSolutionBindingInformationProvider.cs" company="SonarSource SA and Microsoft Corporation">
 //   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
 //   Licensed under the MIT License. See License.txt in the project root for license information.

--- a/src/TestInfrastructure/Framework/ConfigurableStateManager.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableStateManager.cs
@@ -77,10 +77,33 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             this.VerifyActiveSection();
             this.SyncCommandFromActiveSectionAction?.Invoke();
         }
+
+
+        public bool IsConnected { get; set; }
+
+        public IEnumerable<ConnectionInformation> GetConnectedServers()
+        {
+            return this.ConnectedServers;
+        }
+
+        public ConnectionInformation GetConnectedServer(ProjectInformation project)
+        {
+            ConnectionInformation conn;
+            if (!this.ProjectServerMap.TryGetValue(project, out conn))
+            {
+                Assert.Inconclusive("Test setup: project-server mapping is not available for the specified project");
+            }
+
+            return conn;
+        }
         #endregion
 
         #region Test helpers
         public IHost Host { get; set; }
+
+        public HashSet<ConnectionInformation> ConnectedServers { get; } = new HashSet<ConnectionInformation>();
+
+        public Dictionary<ProjectInformation, ConnectionInformation> ProjectServerMap { get; } = new Dictionary<ProjectInformation, ConnectionInformation>();
 
         public TransferableVisualState ManagedState { get; set; }
 


### PR DESCRIPTION
Before proceeding with the SQ condition of SVS-9, I'm cleaning up the service since the state that it holds needs to be kept at the state manager level.

Please review c501d31 only (this PR builds on an already pending PR).

The state manager holds the state and disposes of connection information when disconnected.
