### PR TITLE
[SVS-9] Show info bar when the quality profile has changed

### DIFF
--- a/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
+++ b/src/Integration.UnitTests/Binding/BindingWorkflowTests.cs
@@ -84,15 +84,15 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var additionalFiles = new[] { new AdditionalFile { FileName = "abc.xml", Content = new byte[] { 1, 2, 3 } } };
             RoslynExportProfile export = RoslynExportProfileHelper.CreateExport(ruleSet, nugetPackages, additionalFiles);
 
-            var language = Language.CSharp;
-            QualityProfile profile = this.ConfigureProfileExport(testSubject, export, language, RuleSetGroup.VB);
+            var language = Language.VBNET;
+            QualityProfile profile = this.ConfigureProfileExport(testSubject, export, language, LanguageGroup.VB);
 
             // Act
             testSubject.DownloadQualityProfile(controller, CancellationToken.None, notifications, new[] { language });
 
             // Verify
-            RuleSetAssert.AreEqual(ruleSet, testSubject.Rulesets[RuleSetGroup.VB], "Unexpected rule set");
-            Assert.AreSame(profile, testSubject.QualityProfiles[RuleSetGroup.VB]);
+            RuleSetAssert.AreEqual(ruleSet, testSubject.Rulesets[LanguageGroup.VB], "Unexpected rule set");
+            Assert.AreSame(profile, testSubject.QualityProfiles[LanguageGroup.VB]);
             VerifyNuGetPackgesDownloaded(nugetPackages, testSubject);
             this.outputWindowPane.AssertOutputStrings(0);
             controller.AssertNumberOfAbortRequests(0);
@@ -114,14 +114,14 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             ConfigurableProgressController controller = new ConfigurableProgressController();
 
             var language = Language.CSharp;
-            this.ConfigureProfileExport(testSubject, null, language, RuleSetGroup.VB);
+            this.ConfigureProfileExport(testSubject, null, language, LanguageGroup.VB);
 
             // Act
             testSubject.DownloadQualityProfile(controller, CancellationToken.None, new ConfigurableProgressStepExecutionEvents(), new[] { language });
 
             // Verify
-            Assert.IsFalse(testSubject.Rulesets.ContainsKey(RuleSetGroup.VB), "Not expecting any rules for this language");
-            Assert.IsFalse(testSubject.Rulesets.ContainsKey(RuleSetGroup.CSharp), "Not expecting any rules");
+            Assert.IsFalse(testSubject.Rulesets.ContainsKey(LanguageGroup.VB), "Not expecting any rules for this language");
+            Assert.IsFalse(testSubject.Rulesets.ContainsKey(LanguageGroup.CSharp), "Not expecting any rules");
             this.outputWindowPane.AssertOutputStrings(1);
             controller.AssertNumberOfAbortRequests(1);
         }
@@ -434,12 +434,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             return packageInstaller;
         }
 
-        private QualityProfile ConfigureProfileExport(BindingWorkflow testSubject, RoslynExportProfile export, Language language, RuleSetGroup group)
+        private QualityProfile ConfigureProfileExport(BindingWorkflow testSubject, RoslynExportProfile export, Language language, LanguageGroup group)
         {
             var profile = new QualityProfile { Language = language.ServerKey };
             this.sonarQubeService.ReturnProfile[language.ServerKey] = profile;
             this.sonarQubeService.ReturnExport[profile] = export;
-            testSubject.LanguageToGroupMapping[language] = group;
 
             return profile;
         }

--- a/src/Integration.UnitTests/Binding/ProjectBindingOperationTests.cs
+++ b/src/Integration.UnitTests/Binding/ProjectBindingOperationTests.cs
@@ -74,7 +74,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
 
             // Verify
             Assert.AreEqual(@"c:\solution\Project\project.proj", testSubject.ProjectFullPath);
-            Assert.AreEqual(RuleSetGroup.VB, testSubject.ProjectGroup);
+            Assert.AreEqual(LanguageGroup.VB, testSubject.ProjectGroup);
             CollectionAssert.AreEquivalent(new[] { prop1, prop2 }, testSubject.PropertyInformationMap.Keys.ToArray(), "Unexpected properties");
 
             foreach (var prop in new[] { prop1, prop2 })
@@ -98,7 +98,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
 
             // Verify
             Assert.AreEqual(@"c:\solution\Project\project.proj", testSubject.ProjectFullPath);
-            Assert.AreEqual(RuleSetGroup.VB, testSubject.ProjectGroup);
+            Assert.AreEqual(LanguageGroup.VB, testSubject.ProjectGroup);
             CollectionAssert.AreEquivalent(new[] { prop1, prop2 }, testSubject.PropertyInformationMap.Keys.ToArray(), "Unexpected properties");
 
             foreach (var prop in new[] { prop1, prop2 })
@@ -121,7 +121,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
 
             // Verify
             Assert.AreEqual(@"c:\solution\Project\project.proj", testSubject.ProjectFullPath);
-            Assert.AreEqual(RuleSetGroup.VB, testSubject.ProjectGroup);
+            Assert.AreEqual(LanguageGroup.VB, testSubject.ProjectGroup);
             CollectionAssert.AreEquivalent(new[] { prop1, prop2 }, testSubject.PropertyInformationMap.Keys.ToArray(), "Unexpected properties");
 
             foreach (var prop in new[] { prop1, prop2 })
@@ -145,7 +145,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
 
             // Verify
             Assert.AreEqual(@"c:\solution\Project\project.proj", testSubject.ProjectFullPath);
-            Assert.AreEqual(RuleSetGroup.CSharp, testSubject.ProjectGroup);
+            Assert.AreEqual(LanguageGroup.CSharp, testSubject.ProjectGroup);
             CollectionAssert.AreEquivalent(new[] { prop1, prop2 }, testSubject.PropertyInformationMap.Keys.ToArray(), "Unexpected properties");
 
             Assert.AreEqual(ProjectBindingOperation.DefaultProjectRuleSet, testSubject.PropertyInformationMap[prop1].CurrentRuleSetFilePath);
@@ -158,7 +158,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         public void ProjectBindingOperation_Prepare_VariousRuleSetsInProjects()
         {
             // Setup
-            this.ruleStore.RegisterRuleSetPath(RuleSetGroup.VB, @"c:\Solution\sln.ruleset");
+            this.ruleStore.RegisterRuleSetPath(LanguageGroup.VB, @"c:\Solution\sln.ruleset");
             ProjectBindingOperation testSubject = this.CreateTestSubject();
             this.projectMock.SetVBProjectKind();
             PropertyMock customRuleSetProperty1 = CreateProperty(this.projectMock, "config1", "Custom.ruleset");
@@ -197,7 +197,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         public void ProjectBindingOperation_Prepare_SameNonDefaultRuleSetsInProject()
         {
             // Setup
-            this.ruleStore.RegisterRuleSetPath(RuleSetGroup.VB, @"c:\Solution\sln.ruleset");
+            this.ruleStore.RegisterRuleSetPath(LanguageGroup.VB, @"c:\Solution\sln.ruleset");
             ProjectBindingOperation testSubject = this.CreateTestSubject();
             this.projectMock.SetVBProjectKind();
             PropertyMock customRuleSetProperty1 = CreateProperty(this.projectMock, "config1", "Custom.ruleset");
@@ -224,7 +224,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         public void ProjectBindingOperation_Prepare_SameDefaultRuleSetsInProject()
         {
             // Setup
-            this.ruleStore.RegisterRuleSetPath(RuleSetGroup.VB, @"c:\Solution\sln.ruleset");
+            this.ruleStore.RegisterRuleSetPath(LanguageGroup.VB, @"c:\Solution\sln.ruleset");
             ProjectBindingOperation testSubject = this.CreateTestSubject();
             this.projectMock.SetVBProjectKind();
             PropertyMock defaultRuleSetProperty1 = CreateProperty(this.projectMock, "config1", ProjectBindingOperation.DefaultProjectRuleSet);
@@ -251,7 +251,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         public void ProjectBindingOperation_Prepare_Cancellation()
         {
             // Setup
-            this.ruleStore.RegisterRuleSetPath(RuleSetGroup.CSharp, @"c:\Solution\sln.ruleset");
+            this.ruleStore.RegisterRuleSetPath(LanguageGroup.CSharp, @"c:\Solution\sln.ruleset");
             ProjectBindingOperation testSubject = this.CreateTestSubject();
             this.projectMock.SetCSProjectKind();
             PropertyMock prop = CreateProperty(this.projectMock, "config1", ProjectBindingOperation.DefaultProjectRuleSet);
@@ -279,7 +279,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             this.serviceProvider.RegisterService(typeof(IProjectSystemHelper), this.projectSystemHelper);
             ProjectBindingOperation testSubject = this.CreateTestSubject();
             this.projectMock.SetCSProjectKind();
-            this.ruleStore.RegisterRuleSetPath(RuleSetGroup.CSharp, @"c:\Solution\sln.ruleset");
+            this.ruleStore.RegisterRuleSetPath(LanguageGroup.CSharp, @"c:\Solution\sln.ruleset");
             PropertyMock prop = CreateProperty(this.projectMock, "config1", ProjectBindingOperation.DefaultProjectRuleSet);
             testSubject.Initialize();
             testSubject.Prepare(CancellationToken.None);

--- a/src/Integration.UnitTests/Binding/SolutionBindingOperationTests.cs
+++ b/src/Integration.UnitTests/Binding/SolutionBindingOperationTests.cs
@@ -92,9 +92,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         {
             // Setup
             SolutionBindingOperation testSubject = this.CreateTestSubject("key"); 
-            var ruleSetMap = new Dictionary<RuleSetGroup, RuleSet>();
-            ruleSetMap[RuleSetGroup.CSharp] = new RuleSet("cs");
-            ruleSetMap[RuleSetGroup.VB] = new RuleSet("vb");
+            var ruleSetMap = new Dictionary<LanguageGroup, RuleSet>();
+            ruleSetMap[LanguageGroup.CSharp] = new RuleSet("cs");
+            ruleSetMap[LanguageGroup.VB] = new RuleSet("vb");
 
             // Sanity
             Assert.AreEqual(0, testSubject.RuleSetsInformationMap.Count, "Not expecting any registered rulesets");
@@ -104,8 +104,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
 
             // Verify
             CollectionAssert.AreEquivalent(ruleSetMap.Keys.ToArray(), testSubject.RuleSetsInformationMap.Keys.ToArray());
-            Assert.AreSame(ruleSetMap[RuleSetGroup.CSharp], testSubject.RuleSetsInformationMap[RuleSetGroup.CSharp].RuleSet);
-            Assert.AreSame(ruleSetMap[RuleSetGroup.VB], testSubject.RuleSetsInformationMap[RuleSetGroup.VB].RuleSet);
+            Assert.AreSame(ruleSetMap[LanguageGroup.CSharp], testSubject.RuleSetsInformationMap[LanguageGroup.CSharp].RuleSet);
+            Assert.AreSame(ruleSetMap[LanguageGroup.VB], testSubject.RuleSetsInformationMap[LanguageGroup.VB].RuleSet);
         }
 
         [TestMethod]
@@ -118,25 +118,25 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             // Act + Verify
             using (new AssertIgnoreScope())
             {
-                Assert.IsNull(testSubject.GetRuleSetFilePath(RuleSetGroup.CSharp));
+                Assert.IsNull(testSubject.GetRuleSetFilePath(LanguageGroup.CSharp));
             }
 
             // Test case 2: known ruleset map
             // Setup
-            var ruleSetMap = new Dictionary<RuleSetGroup, RuleSet>();
-            ruleSetMap[RuleSetGroup.CSharp] = new RuleSet("cs");
-            ruleSetMap[RuleSetGroup.VB] = new RuleSet("vb");
+            var ruleSetMap = new Dictionary<LanguageGroup, RuleSet>();
+            ruleSetMap[LanguageGroup.CSharp] = new RuleSet("cs");
+            ruleSetMap[LanguageGroup.VB] = new RuleSet("vb");
 
             testSubject.RegisterKnownRuleSets(ruleSetMap);
             testSubject.Initialize(new ProjectMock[0], GetQualityProfiles());
             testSubject.Prepare(CancellationToken.None);
 
             // Act
-            string filePath = testSubject.GetRuleSetFilePath(RuleSetGroup.CSharp);
+            string filePath = testSubject.GetRuleSetFilePath(LanguageGroup.CSharp);
 
             // Verify
             Assert.IsFalse(string.IsNullOrWhiteSpace(filePath));
-            Assert.AreEqual(testSubject.RuleSetsInformationMap[RuleSetGroup.CSharp].NewRuleSetFilePath, filePath, "NewRuleSetFilePath is expected to be updated during Prepare and returned now");
+            Assert.AreEqual(testSubject.RuleSetsInformationMap[LanguageGroup.CSharp].NewRuleSetFilePath, filePath, "NewRuleSetFilePath is expected to be updated during Prepare and returned now");
         }
 
         [TestMethod]
@@ -186,9 +186,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
 
             SolutionBindingOperation testSubject = this.CreateTestSubject("key");
 
-            var ruleSetMap = new Dictionary<RuleSetGroup, RuleSet>();
-            ruleSetMap[RuleSetGroup.CSharp] = new RuleSet("cs");
-            ruleSetMap[RuleSetGroup.VB] = new RuleSet("vb");
+            var ruleSetMap = new Dictionary<LanguageGroup, RuleSet>();
+            ruleSetMap[LanguageGroup.CSharp] = new RuleSet("cs");
+            ruleSetMap[LanguageGroup.VB] = new RuleSet("vb");
 
             testSubject.RegisterKnownRuleSets(ruleSetMap);
             testSubject.Initialize(projects, GetQualityProfiles());
@@ -201,8 +201,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
 
             // Sanity
             this.sccFileSystem.AssertDirectoryNotExists(sonarQubeRulesDirectory);
-            Assert.AreEqual(@"c:\solution\SonarQube\keyCSharp.ruleset", testSubject.RuleSetsInformationMap[RuleSetGroup.CSharp].NewRuleSetFilePath);
-            Assert.AreEqual(@"c:\solution\SonarQube\keyVB.ruleset", testSubject.RuleSetsInformationMap[RuleSetGroup.VB].NewRuleSetFilePath);
+            Assert.AreEqual(@"c:\solution\SonarQube\keyCSharp.ruleset", testSubject.RuleSetsInformationMap[LanguageGroup.CSharp].NewRuleSetFilePath);
+            Assert.AreEqual(@"c:\solution\SonarQube\keyVB.ruleset", testSubject.RuleSetsInformationMap[LanguageGroup.VB].NewRuleSetFilePath);
             
             // Act
             testSubject.Prepare(CancellationToken.None);
@@ -233,9 +233,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             var projects = new[] { csProject, vbProject };
 
             SolutionBindingOperation testSubject = this.CreateTestSubject("key");
-            var ruleSetMap = new Dictionary<RuleSetGroup, RuleSet>();
-            ruleSetMap[RuleSetGroup.CSharp] = new RuleSet("cs");
-            ruleSetMap[RuleSetGroup.VB] = new RuleSet("vb");
+            var ruleSetMap = new Dictionary<LanguageGroup, RuleSet>();
+            ruleSetMap[LanguageGroup.CSharp] = new RuleSet("cs");
+            ruleSetMap[LanguageGroup.VB] = new RuleSet("vb");
 
             testSubject.RegisterKnownRuleSets(ruleSetMap);
             testSubject.Initialize(projects, GetQualityProfiles());
@@ -251,8 +251,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             }
 
             // Verify
-            Assert.AreEqual(@"c:\solution\SonarQube\keyCSharp.ruleset", testSubject.RuleSetsInformationMap[RuleSetGroup.CSharp].NewRuleSetFilePath);
-            Assert.AreEqual(@"c:\solution\SonarQube\keyVB.ruleset", testSubject.RuleSetsInformationMap[RuleSetGroup.VB].NewRuleSetFilePath);
+            Assert.AreEqual(@"c:\solution\SonarQube\keyCSharp.ruleset", testSubject.RuleSetsInformationMap[LanguageGroup.CSharp].NewRuleSetFilePath);
+            Assert.AreEqual(@"c:\solution\SonarQube\keyVB.ruleset", testSubject.RuleSetsInformationMap[LanguageGroup.VB].NewRuleSetFilePath);
             Assert.IsFalse(prepareCalledForBinder, "Expected to be cancelled as soon as possible i.e. after the first binder");
         }
 
@@ -268,9 +268,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
 
             SolutionBindingOperation testSubject = this.CreateTestSubject("key");
 
-            var ruleSetMap = new Dictionary<RuleSetGroup, RuleSet>();
-            ruleSetMap[RuleSetGroup.CSharp] = new RuleSet("cs");
-            ruleSetMap[RuleSetGroup.VB] = new RuleSet("vb");
+            var ruleSetMap = new Dictionary<LanguageGroup, RuleSet>();
+            ruleSetMap[LanguageGroup.CSharp] = new RuleSet("cs");
+            ruleSetMap[LanguageGroup.VB] = new RuleSet("vb");
 
             testSubject.RegisterKnownRuleSets(ruleSetMap);
             testSubject.Initialize(projects, GetQualityProfiles());
@@ -286,8 +286,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             }
 
             // Verify
-            Assert.IsNotNull(testSubject.RuleSetsInformationMap[RuleSetGroup.CSharp].NewRuleSetFilePath, "Expected to be set before Prepare is called");
-            Assert.IsNotNull(testSubject.RuleSetsInformationMap[RuleSetGroup.VB].NewRuleSetFilePath, "Expected to be set before Prepare is called");
+            Assert.IsNotNull(testSubject.RuleSetsInformationMap[LanguageGroup.CSharp].NewRuleSetFilePath, "Expected to be set before Prepare is called");
+            Assert.IsNotNull(testSubject.RuleSetsInformationMap[LanguageGroup.VB].NewRuleSetFilePath, "Expected to be set before Prepare is called");
             Assert.IsFalse(prepareCalledForBinder, "Expected to be cancelled as soon as possible i.e. before the first binder");
         }
 
@@ -303,11 +303,11 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
             var connectionInformation = new ConnectionInformation(new Uri("http://xyz"));
             SolutionBindingOperation testSubject = this.CreateTestSubject("key", connectionInformation);
 
-            var ruleSetMap = new Dictionary<RuleSetGroup, RuleSet>();
-            ruleSetMap[RuleSetGroup.CSharp] = new RuleSet("cs");
+            var ruleSetMap = new Dictionary<LanguageGroup, RuleSet>();
+            ruleSetMap[LanguageGroup.CSharp] = new RuleSet("cs");
             testSubject.RegisterKnownRuleSets(ruleSetMap);
             var profiles = GetQualityProfiles();
-            profiles[RuleSetGroup.CSharp] = new QualityProfile { Key = "C# Profile", QualityProfileTimestamp = DateTime.Now };
+            profiles[LanguageGroup.CSharp] = new QualityProfile { Key = "C# Profile", QualityProfileTimestamp = DateTime.Now };
             testSubject.Initialize(projects, profiles);
             testSubject.Binders.Clear(); // Ignore the real binders, not part of this test scope
             bool commitCalledForBinder = false;
@@ -318,9 +318,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
                 Assert.AreEqual(connectionInformation.ServerUri, bindingInfo.ServerUri);
                 Assert.AreEqual(1, bindingInfo.Profiles.Count);
 
-                QualityProfile csProfile = profiles[RuleSetGroup.CSharp];
-                Assert.AreEqual(csProfile.Key, bindingInfo.Profiles[RuleSetGroup.CSharp].ProfileKey);
-                Assert.AreEqual(csProfile.QualityProfileTimestamp, bindingInfo.Profiles[RuleSetGroup.CSharp].ProfileTimestamp);
+                QualityProfile csProfile = profiles[LanguageGroup.CSharp];
+                Assert.AreEqual(csProfile.Key, bindingInfo.Profiles[LanguageGroup.CSharp].ProfileKey);
+                Assert.AreEqual(csProfile.QualityProfileTimestamp, bindingInfo.Profiles[LanguageGroup.CSharp].ProfileTimestamp);
 
                 return "Doesn't matter";
             };
@@ -341,7 +341,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
         [TestMethod]
         public void SolutionBindingOperation_RuleSetInformation_Ctor_ArgChecks()
         {
-            Exceptions.Expect<ArgumentNullException>(() => new SolutionBindingOperation.RuleSetInformation(RuleSetGroup.CSharp, null));
+            Exceptions.Expect<ArgumentNullException>(() => new SolutionBindingOperation.RuleSetInformation(LanguageGroup.CSharp, null));
         }
 
         #endregion
@@ -354,9 +354,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests.Binding
                 projectKey);
         }
 
-        private static Dictionary<RuleSetGroup, QualityProfile> GetQualityProfiles()
+        private static Dictionary<LanguageGroup, QualityProfile> GetQualityProfiles()
         {
-            return new Dictionary<RuleSetGroup, QualityProfile>();
+            return new Dictionary<LanguageGroup, QualityProfile>();
         }
         #endregion
     }

--- a/src/Integration.UnitTests/Integration.UnitTests.csproj
+++ b/src/Integration.UnitTests/Integration.UnitTests.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Connection\ConnectionInformationDialogTests.cs" />
     <Compile Include="Framework\ConfigurableCredentialStore.cs" />
     <Compile Include="IServiceProviderExtensionsTests.cs" />
+    <Compile Include="LanguageGroupHelperTests.cs" />
     <Compile Include="LocalServices\ErrorListInfoBarControllerTests.cs" />
     <Compile Include="LocalServices\RuleSetSerializerTests.cs" />
     <Compile Include="LocalServices\SolutionBindingInformationProviderTests.cs" />

--- a/src/Integration.UnitTests/Integration.UnitTests.csproj
+++ b/src/Integration.UnitTests/Integration.UnitTests.csproj
@@ -141,6 +141,7 @@
     <Compile Include="Framework\ConfigurableCredentialStore.cs" />
     <Compile Include="IServiceProviderExtensionsTests.cs" />
     <Compile Include="LanguageGroupHelperTests.cs" />
+    <Compile Include="LocalServices\ErrorListInfoBarController.QualityProfileBackgroundProcessorTests.cs" />
     <Compile Include="LocalServices\ErrorListInfoBarControllerTests.cs" />
     <Compile Include="LocalServices\RuleSetSerializerTests.cs" />
     <Compile Include="LocalServices\SolutionBindingInformationProviderTests.cs" />

--- a/src/Integration.UnitTests/LanguageGroupHelperTests.cs
+++ b/src/Integration.UnitTests/LanguageGroupHelperTests.cs
@@ -1,0 +1,56 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="LanguageGroupHelperTests.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests
+{
+    [TestClass]
+    public class LanguageGroupHelperTests
+    {
+        [TestMethod]
+        public void LanguageGroupHelper_GerLanguage()
+        {
+            Assert.AreSame(Language.CSharp, LanguageGroupHelper.GerLanguage(LanguageGroup.CSharp));
+            Assert.AreSame(Language.VBNET, LanguageGroupHelper.GerLanguage(LanguageGroup.VB));
+            Assert.AreSame(Language.Unknown, LanguageGroupHelper.GerLanguage(LanguageGroup.Unknown));
+
+            using (new AssertIgnoreScope())
+            {
+                Exceptions.Expect<InvalidOperationException>(()=>LanguageGroupHelper.GerLanguage((LanguageGroup)int.MinValue));
+            }
+        }
+
+        [TestMethod]
+        public void LanguageGroupHelper_GetLanguageGroup()
+        {
+            Assert.AreEqual(LanguageGroup.CSharp, LanguageGroupHelper.GetLanguageGroup(Language.CSharp));
+            Assert.AreEqual(LanguageGroup.VB, LanguageGroupHelper.GetLanguageGroup(Language.VBNET));
+            Assert.AreEqual(LanguageGroup.Unknown, LanguageGroupHelper.GetLanguageGroup(Language.Unknown));
+            Assert.AreEqual(LanguageGroup.Unknown, LanguageGroupHelper.GetLanguageGroup(new Language("Java", "Java", new Guid().ToString())));
+        }
+
+
+        [TestMethod]
+        public void LanguageGroupHelper_GetProjectGroup()
+        {
+            // C#
+            var csProject = new ProjectMock("cs.proj");
+            csProject.SetCSProjectKind();
+            Assert.AreEqual(LanguageGroup.CSharp, LanguageGroupHelper.GetProjectGroup(csProject));
+
+            // VB
+            var vbProject = new ProjectMock("vb.proj");
+            vbProject.SetVBProjectKind();
+            Assert.AreEqual(LanguageGroup.VB, LanguageGroupHelper.GetProjectGroup(vbProject));
+
+            // Other
+            Assert.AreEqual(LanguageGroup.Unknown, LanguageGroupHelper.GetProjectGroup(new ProjectMock("other.proj")));
+        }
+    }
+}

--- a/src/Integration.UnitTests/LanguageGroupHelperTests.cs
+++ b/src/Integration.UnitTests/LanguageGroupHelperTests.cs
@@ -14,15 +14,15 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
     public class LanguageGroupHelperTests
     {
         [TestMethod]
-        public void LanguageGroupHelper_GerLanguage()
+        public void LanguageGroupHelper_GetLanguage()
         {
-            Assert.AreSame(Language.CSharp, LanguageGroupHelper.GerLanguage(LanguageGroup.CSharp));
-            Assert.AreSame(Language.VBNET, LanguageGroupHelper.GerLanguage(LanguageGroup.VB));
-            Assert.AreSame(Language.Unknown, LanguageGroupHelper.GerLanguage(LanguageGroup.Unknown));
+            Assert.AreSame(Language.CSharp, LanguageGroupHelper.GetLanguage(LanguageGroup.CSharp));
+            Assert.AreSame(Language.VBNET, LanguageGroupHelper.GetLanguage(LanguageGroup.VB));
+            Assert.AreSame(Language.Unknown, LanguageGroupHelper.GetLanguage(LanguageGroup.Unknown));
 
             using (new AssertIgnoreScope())
             {
-                Exceptions.Expect<InvalidOperationException>(()=>LanguageGroupHelper.GerLanguage((LanguageGroup)int.MinValue));
+                Exceptions.Expect<InvalidOperationException>(()=>LanguageGroupHelper.GetLanguage((LanguageGroup)int.MinValue));
             }
         }
 

--- a/src/Integration.UnitTests/LocalServices/ErrorListInfoBarController.QualityProfileBackgroundProcessorTests.cs
+++ b/src/Integration.UnitTests/LocalServices/ErrorListInfoBarController.QualityProfileBackgroundProcessorTests.cs
@@ -22,7 +22,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
         private ConfigurableServiceProvider serviceProvider;
         private ConfigurableHost host;
         private ConfigurableVsProjectSystemHelper projectSystem;
-        private ConfigurableVsGeneralOutputWindowPane outputWindow;
+        private ConfigurableVsOutputWindowPane outputWindowPane;
         private ConfigurableSolutionBindingSerializer bindingSerializer;
 
         [TestInitialize]
@@ -34,8 +34,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             this.projectSystem = new ConfigurableVsProjectSystemHelper(this.serviceProvider);
             this.serviceProvider.RegisterService(typeof(IProjectSystemHelper), this.projectSystem);
 
-            this.outputWindow = new ConfigurableVsGeneralOutputWindowPane();
-            this.serviceProvider.RegisterService(typeof(SVsGeneralOutputWindowPane), this.outputWindow);
+            var outputWindow = new ConfigurableVsOutputWindow();
+            this.outputWindowPane = outputWindow.GetOrCreateSonarLintPane();
+            this.serviceProvider.RegisterService(typeof(SVsOutputWindow), outputWindow);
 
             this.bindingSerializer = new ConfigurableSolutionBindingSerializer();
             this.serviceProvider.RegisterService(typeof(Persistence.ISolutionBindingSerializer), this.bindingSerializer);
@@ -89,7 +90,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             testSubject.QueueCheckIfUpdateIsRequired(this.AssertIfCalled);
 
             // Verify
-            this.outputWindow.AssertOutputStrings(0);
+            this.outputWindowPane.AssertOutputStrings(0);
         }
 
         [TestMethod]
@@ -103,7 +104,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             testSubject.QueueCheckIfUpdateIsRequired(this.AssertIfCalled);
 
             // Verify
-            this.outputWindow.AssertOutputStrings(0);
+            this.outputWindowPane.AssertOutputStrings(0);
         }
 
         [TestMethod]
@@ -124,7 +125,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
             // Verify
             Assert.AreEqual(1, called, "Expected the update action to be called");
-            this.outputWindow.AssertOutputStrings(Strings.SonarLintProfileCheckNoProfiles);
+            this.outputWindowPane.AssertOutputStrings(Strings.SonarLintProfileCheckNoProfiles);
         }
 
         [TestMethod]
@@ -319,7 +320,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
                 Assert.AreEqual(0, called, "Not expected to call the update action");
             }
 
-            this.outputWindow.AssertOutputStrings(expectedOutput);
+            this.outputWindowPane.AssertOutputStrings(expectedOutput);
         }
 
         private ErrorListInfoBarController.QualityProfileBackgroundProcessor GetTestSubject()

--- a/src/Integration.UnitTests/LocalServices/ErrorListInfoBarController.QualityProfileBackgroundProcessorTests.cs
+++ b/src/Integration.UnitTests/LocalServices/ErrorListInfoBarController.QualityProfileBackgroundProcessorTests.cs
@@ -1,0 +1,386 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ErrorListInfoBarController.QualityProfileBackgroundProcessorTests.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using EnvDTE;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarLint.VisualStudio.Integration.Persistence;
+using SonarLint.VisualStudio.Integration.Resources;
+using System;
+using System.Threading;
+using System.Windows.Threading;
+
+namespace SonarLint.VisualStudio.Integration.UnitTests
+{
+    [TestClass]
+    public class ErrorListInfoBarController_QualityProfileBackgroundProcessorTests
+    {
+        private ConfigurableServiceProvider serviceProvider;
+        private ConfigurableHost host;
+        private ConfigurableVsProjectSystemHelper projectSystem;
+        private ConfigurableVsGeneralOutputWindowPane outputWindow;
+        private ConfigurableSolutionBindingSerializer bindingSerializer;
+
+        [TestInitialize]
+        public void TestInit()
+        {
+            this.serviceProvider = new ConfigurableServiceProvider();
+            this.host = new ConfigurableHost(this.serviceProvider, Dispatcher.CurrentDispatcher);
+
+            this.projectSystem = new ConfigurableVsProjectSystemHelper(this.serviceProvider);
+            this.serviceProvider.RegisterService(typeof(IProjectSystemHelper), this.projectSystem);
+
+            this.outputWindow = new ConfigurableVsGeneralOutputWindowPane();
+            this.serviceProvider.RegisterService(typeof(SVsGeneralOutputWindowPane), this.outputWindow);
+
+            this.bindingSerializer = new ConfigurableSolutionBindingSerializer();
+            this.serviceProvider.RegisterService(typeof(Persistence.ISolutionBindingSerializer), this.bindingSerializer);
+        }
+
+        #region Tests
+        [TestMethod]
+        public void QualityProfileBackgroundProcessor_ArgChecks()
+        {
+            // Act + Verify
+            Exceptions.Expect<ArgumentNullException>(() => 
+                new ErrorListInfoBarController.QualityProfileBackgroundProcessor(null));
+        }
+
+        [TestMethod]
+        public void QualityProfileBackgroundProcessor_LifeCycle()
+        {
+            // Setup
+            var testSubject = this.GetTestSubject();
+
+            // Verify
+            Assert.IsNotNull(testSubject.TokenSource);
+            Assert.AreNotEqual(CancellationToken.None, testSubject.TokenSource.Token);
+
+            // Act
+            testSubject.Dispose();
+
+            // Verify
+            Exceptions.Expect<ObjectDisposedException>(() => testSubject.TokenSource.Cancel());
+        }
+
+        [TestMethod]
+        public void QualityProfileBackgroundProcessor_QueueCheckIfUpdateIsRequired_ArgChecks()
+        {
+            // Setup
+            var testSubject = this.GetTestSubject();
+
+            // Act + Verify
+            Exceptions.Expect<ArgumentNullException>(() => testSubject.QueueCheckIfUpdateIsRequired(null));
+        }
+
+        [TestMethod]
+        public void QualityProfileBackgroundProcessor_QueueCheckIfUpdateIsRequired_NoFilteredProjects()
+        {
+            // Setup
+            var testSubject = this.GetTestSubject();
+            this.projectSystem.Projects = new Project[] { new ProjectMock("project.proj") };
+            this.projectSystem.FilteredProjects = null;
+
+            // Act
+            testSubject.QueueCheckIfUpdateIsRequired(this.AssertIfCalled);
+
+            // Verify
+            this.outputWindow.AssertOutputStrings(0);
+        }
+
+        [TestMethod]
+        public void QualityProfileBackgroundProcessor_QueueCheckIfUpdateIsRequired_NoSolutionBinding()
+        {
+            // Setup
+            var testSubject = this.GetTestSubject();
+            var project1 = new ProjectMock("validProject1.csproj");
+            project1.SetCSProjectKind();
+            var project2 = new ProjectMock("validProject2.csproj");
+            project2.SetCSProjectKind();
+            this.projectSystem.FilteredProjects = new[] { project1, project2 };
+
+            // Act
+            testSubject.QueueCheckIfUpdateIsRequired(this.AssertIfCalled);
+
+            // Verify
+            this.outputWindow.AssertOutputStrings(0);
+        }
+
+        [TestMethod]
+        public void QualityProfileBackgroundProcessor_QueueCheckIfUpdateIsRequired_NoProfiles_RequiresUpdate()
+        {
+            // Setup
+            var testSubject = this.GetTestSubject();
+            var project1 = new ProjectMock("validProject1.csproj");
+            project1.SetCSProjectKind();
+            var project2 = new ProjectMock("validProject2.csproj");
+            project2.SetCSProjectKind();
+            this.projectSystem.FilteredProjects = new[] { project1, project2 };
+            this.bindingSerializer.CurrentBinding = new Persistence.BoundSonarQubeProject();
+            int called = 0;
+
+            // Act
+            testSubject.QueueCheckIfUpdateIsRequired(() => called++);
+
+            // Verify
+            Assert.AreEqual(1, called, "Expected the update action to be called");
+            this.outputWindow.AssertOutputStrings(Strings.SonarLintProfileCheckNoProfiles);
+        }
+
+        [TestMethod]
+        public void QualityProfileBackgroundProcessor_BackgroundTask_DifferentTimestamp_RequiresUpdate()
+        {
+            // Setup
+            var testSubject = this.GetTestSubject();
+            var project1 = new ProjectMock("validProject1.csproj");
+            project1.SetCSProjectKind();
+            var project2 = new ProjectMock("validProject2.csproj");
+            project2.SetCSProjectKind();
+            this.projectSystem.FilteredProjects = new[] { project1, project2 };
+            this.bindingSerializer.CurrentBinding = new BoundSonarQubeProject
+            {
+                ServerUri = new Uri("http://server"),
+                ProjectKey = "ProjectKey",
+                Profiles = new System.Collections.Generic.Dictionary<LanguageGroup, ApplicableQualityProfile>()
+            };
+            this.bindingSerializer.CurrentBinding.Profiles[LanguageGroup.CSharp] = new ApplicableQualityProfile
+            {
+                ProfileKey = LanguageGroup.CSharp.ToString(), // Same profile key
+                ProfileTimestamp = DateTime.Now
+            };
+            this.ConfigureValidSonarQubeServiceWrapper(this.bindingSerializer.CurrentBinding, DateTime.Now.AddMinutes(-1), LanguageGroup.CSharp);
+
+            // Act + Verify
+            VerifyBackgroundExecution(true, testSubject,
+                Strings.SonarLintProfileCheck,
+                Strings.SonarLintProfileCheckProfileUpdated);
+        }
+
+        [TestMethod]
+        public void QualityProfileBackgroundProcessor_BackgroundTask_NoTimestampDifferentProfile_RequiresUpdate()
+        {
+            // Setup
+            var testSubject = this.GetTestSubject();
+            var project1 = new ProjectMock("validProject1.csproj");
+            project1.SetCSProjectKind();
+            var project2 = new ProjectMock("validProject2.csproj");
+            project2.SetCSProjectKind();
+            this.projectSystem.FilteredProjects = new[] { project1, project2 };
+            this.bindingSerializer.CurrentBinding = new BoundSonarQubeProject
+            {
+                ServerUri = new Uri("http://server"),
+                ProjectKey = "ProjectKey",
+                Profiles = new System.Collections.Generic.Dictionary<LanguageGroup, ApplicableQualityProfile>()
+            };
+            this.bindingSerializer.CurrentBinding.Profiles[LanguageGroup.CSharp] = new ApplicableQualityProfile
+            {
+                ProfileKey = LanguageGroup.CSharp.ToString() + "Old", // Different profile key
+                ProfileTimestamp = null
+            };
+            this.ConfigureValidSonarQubeServiceWrapper(this.bindingSerializer.CurrentBinding, null, LanguageGroup.CSharp);
+
+            // Act + Verify
+            VerifyBackgroundExecution(true, testSubject,
+                Strings.SonarLintProfileCheck,
+                Strings.SonarLintProfileCheckDifferentProfile);
+        }
+
+        [TestMethod]
+        public void QualityProfileBackgroundProcessor_BackgroundTask_SameTimestampDifferentProfile_RequiresUpdate()
+        {
+            // Setup
+            var testSubject = this.GetTestSubject();
+            var project1 = new ProjectMock("validProject1.csproj");
+            project1.SetCSProjectKind();
+            var project2 = new ProjectMock("validProject2.csproj");
+            project2.SetCSProjectKind();
+            this.projectSystem.FilteredProjects = new[] { project1, project2 };
+            this.bindingSerializer.CurrentBinding = new BoundSonarQubeProject
+            {
+                ServerUri = new Uri("http://server"),
+                ProjectKey = "ProjectKey",
+                Profiles = new System.Collections.Generic.Dictionary<LanguageGroup, ApplicableQualityProfile>()
+            };
+            DateTime sameTimestamp = DateTime.Now;
+            this.bindingSerializer.CurrentBinding.Profiles[LanguageGroup.CSharp] = new ApplicableQualityProfile
+            {
+                ProfileKey = LanguageGroup.CSharp.ToString() + "Old", // Different profile key
+                ProfileTimestamp = sameTimestamp
+            };
+            this.ConfigureValidSonarQubeServiceWrapper(this.bindingSerializer.CurrentBinding, sameTimestamp, LanguageGroup.CSharp);
+
+            // Act + Verify
+            VerifyBackgroundExecution(true, testSubject,
+                Strings.SonarLintProfileCheck,
+                Strings.SonarLintProfileCheckDifferentProfile);
+        }
+
+        [TestMethod]
+        public void QualityProfileBackgroundProcessor_BackgroundTask_SolutionRequiresMoreProfiles_RequiresUpdate()
+        {
+            // Setup
+            var testSubject = this.GetTestSubject();
+            var project1 = new ProjectMock("validProject1.csproj");
+            project1.SetCSProjectKind();
+            var project2 = new ProjectMock("validProject2.csproj");
+            project2.SetVBProjectKind();
+            this.projectSystem.FilteredProjects = new[] { project1, project2 };
+            this.bindingSerializer.CurrentBinding = new BoundSonarQubeProject
+            {
+                ServerUri = new Uri("http://server"),
+                ProjectKey = "ProjectKey",
+                Profiles = new System.Collections.Generic.Dictionary<LanguageGroup, ApplicableQualityProfile>()
+            };
+            // Has only a profile for C#
+            this.bindingSerializer.CurrentBinding.Profiles[LanguageGroup.CSharp] = new ApplicableQualityProfile
+            {
+                ProfileKey = LanguageGroup.CSharp.ToString(),
+                ProfileTimestamp = null
+            };
+            this.ConfigureValidSonarQubeServiceWrapper(this.bindingSerializer.CurrentBinding, null, LanguageGroup.CSharp, LanguageGroup.VB);
+
+            // Act + Verify
+            VerifyBackgroundExecution(true, testSubject,
+                Strings.SonarLintProfileCheck,
+                Strings.SonarLintProfileCheckSolutionRequiresMoreProfiles);
+        }
+
+        [TestMethod]
+        public void QualityProfileBackgroundProcessor_BackgroundTask_HasNotNeededProfile_DoesNotRequireUpdate()
+        {
+            // Setup
+            var testSubject = this.GetTestSubject();
+            var project1 = new ProjectMock("validProject1.csproj");
+            project1.SetCSProjectKind();
+            var project2 = new ProjectMock("validProject2.csproj");
+            project2.SetCSProjectKind();
+            this.projectSystem.FilteredProjects = new[] { project1, project2 };
+            this.bindingSerializer.CurrentBinding = new BoundSonarQubeProject
+            {
+                ServerUri = new Uri("http://server"),
+                ProjectKey = "ProjectKey",
+                Profiles = new System.Collections.Generic.Dictionary<LanguageGroup, ApplicableQualityProfile>()
+            };
+            DateTime sameDate = DateTime.Now;
+            this.bindingSerializer.CurrentBinding.Profiles[LanguageGroup.CSharp] = new ApplicableQualityProfile
+            {
+                ProfileKey = LanguageGroup.CSharp.ToString(), // Same as profile
+                ProfileTimestamp = sameDate
+            };
+            // This profile should not be picked up in practice, no should cause an update to occur
+            this.bindingSerializer.CurrentBinding.Profiles[LanguageGroup.VB] = new ApplicableQualityProfile
+            {
+                ProfileKey = LanguageGroup.VB.ToString(), 
+                ProfileTimestamp = null
+            };
+            this.ConfigureValidSonarQubeServiceWrapper(this.bindingSerializer.CurrentBinding, sameDate, LanguageGroup.CSharp);
+
+            // Act + Verify
+            VerifyBackgroundExecution(false, testSubject,
+                Strings.SonarLintProfileCheck,
+                Strings.SonarLintProfileCheckQualityProfileIsUpToDate);
+        }
+
+        [TestMethod]
+        public void QualityProfileBackgroundProcessor_BackgroundTask_ServiceErrors_DoesNotRequireUpdate()
+        {
+            // Setup
+            var testSubject = this.GetTestSubject();
+            var project1 = new ProjectMock("validProject1.csproj");
+            project1.SetVBProjectKind();
+            this.projectSystem.FilteredProjects = new[] { project1 };
+            this.bindingSerializer.CurrentBinding = new BoundSonarQubeProject
+            {
+                ServerUri = new Uri("http://server"),
+                ProjectKey = "ProjectKey",
+                Profiles = new System.Collections.Generic.Dictionary<LanguageGroup, ApplicableQualityProfile>()
+            };
+            this.bindingSerializer.CurrentBinding.Profiles[LanguageGroup.VB] = new ApplicableQualityProfile
+            {
+                ProfileKey = LanguageGroup.VB.ToString(),
+                ProfileTimestamp = DateTime.Now
+            };
+            this.ConfigureSonarQubeServiceWrapperWithServiceError();
+
+            // Act + Verify
+            VerifyBackgroundExecution(false, testSubject,
+                Strings.SonarLintProfileCheck,
+                Strings.SonarLintProfileCheckFailed);
+        }
+        #endregion
+
+        #region Helpers
+
+        private void VerifyBackgroundExecution(bool updateRequired, ErrorListInfoBarController.QualityProfileBackgroundProcessor testSubject, params string[] expectedOutput)
+        {
+            // Act
+            int called = 0;
+            testSubject.QueueCheckIfUpdateIsRequired(() => called++);
+
+            // Verify
+            Assert.AreEqual(0, called, "Not expected to be immediate");
+            Assert.IsNotNull(testSubject.BackgroundTask, "Expected to start processing in the background");
+
+            // Run the background task
+            Assert.IsTrue(testSubject.BackgroundTask.Wait(TimeSpan.FromSeconds(2)), "Timeout waiting for the background task");
+            Assert.AreEqual(0, called, "The UI thread (this one) should be blocked");
+
+            // Run the UI async action
+            DispatcherHelper.DispatchFrame(DispatcherPriority.Normal); // Allow the BeginInvoke to run
+
+            if (updateRequired)
+            {
+                Assert.AreEqual(1, called, "Expected to call the update action");
+            }
+            else
+            {
+                Assert.AreEqual(0, called, "Not expected to call the update action");
+            }
+
+            this.outputWindow.AssertOutputStrings(expectedOutput);
+        }
+
+        private ErrorListInfoBarController.QualityProfileBackgroundProcessor GetTestSubject()
+        {
+            return new ErrorListInfoBarController.QualityProfileBackgroundProcessor(this.host);
+        }
+
+        private void ConfigureSonarQubeServiceWrapperWithServiceError()
+        {
+            var sqService = new ConfigurableSonarQubeServiceWrapper();
+            this.host.SonarQubeService = sqService;
+            sqService.AllowConnections = false;
+        }
+
+        private void ConfigureValidSonarQubeServiceWrapper(BoundSonarQubeProject binding, DateTime? timestamp, params LanguageGroup[] expectedLanguageProfiles)
+        {
+            var sqService = new ConfigurableSonarQubeServiceWrapper();
+            this.host.SonarQubeService = sqService;
+
+            sqService.AllowConnections = true;
+            sqService.ExpectedConnection = binding.CreateConnectionInformation();
+            sqService.ExpectedProjectKey = binding.ProjectKey;
+
+            foreach (LanguageGroup group in expectedLanguageProfiles)
+            {
+                sqService.ReturnProfile[LanguageGroupHelper.GerLanguage(group).ServerKey] = new Integration.Service.QualityProfile
+                {
+                    Key = group.ToString(),
+                    Language = group.ToString(),
+                    QualityProfileTimestamp = timestamp
+                };
+            }
+        }
+
+        private void AssertIfCalled()
+        {
+            Assert.Fail("Not expected to be called");
+        }
+        #endregion
+
+    }
+}

--- a/src/Integration.UnitTests/LocalServices/SolutionBindingInformationProviderTests.cs
+++ b/src/Integration.UnitTests/LocalServices/SolutionBindingInformationProviderTests.cs
@@ -278,7 +278,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
         private void SetValidSolutionRuleSet(RuleSet ruleSet)
         {
-            string expectedSolutionRuleSet = ((ISolutionRuleSetsInformationProvider)this.ruleSetInfoProvider).CalculateSolutionSonarQubeRuleSetFilePath("projectKey", RuleSetGroup.CSharp);
+            string expectedSolutionRuleSet = ((ISolutionRuleSetsInformationProvider)this.ruleSetInfoProvider).CalculateSolutionSonarQubeRuleSetFilePath("projectKey", LanguageGroup.CSharp);
             ruleSet.FilePath = expectedSolutionRuleSet;
 
             this.ruleSetSerializer.RegisterRuleSet(ruleSet);

--- a/src/Integration.UnitTests/LocalServices/SolutionRuleSetsInformationProviderTests.cs
+++ b/src/Integration.UnitTests/LocalServices/SolutionRuleSetsInformationProviderTests.cs
@@ -152,8 +152,8 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var testSubject = new SolutionRuleSetsInformationProvider(this.serviceProvider);
 
             // Act Verify
-            Exceptions.Expect<ArgumentNullException>(() => testSubject.CalculateSolutionSonarQubeRuleSetFilePath(null, RuleSetGroup.CSharp));
-            Exceptions.Expect<ArgumentNullException>(() => testSubject.CalculateSolutionSonarQubeRuleSetFilePath(null, RuleSetGroup.VB));
+            Exceptions.Expect<ArgumentNullException>(() => testSubject.CalculateSolutionSonarQubeRuleSetFilePath(null, LanguageGroup.CSharp));
+            Exceptions.Expect<ArgumentNullException>(() => testSubject.CalculateSolutionSonarQubeRuleSetFilePath(null, LanguageGroup.VB));
         }
 
         [TestMethod]
@@ -168,14 +168,14 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
             // Case 1: VB + invalid path characters
             // Act
-            string ruleSetPath = testSubject.CalculateSolutionSonarQubeRuleSetFilePath("MyKey" + Path.GetInvalidPathChars().First(), RuleSetGroup.VB);
+            string ruleSetPath = testSubject.CalculateSolutionSonarQubeRuleSetFilePath("MyKey" + Path.GetInvalidPathChars().First(), LanguageGroup.VB);
 
             // Verify
             Assert.AreEqual(@"z:\folder\solution\SonarQube\MyKey_VB.ruleset", ruleSetPath);
 
             // Case 2: C# + valid path characters
             // Act
-            ruleSetPath = testSubject.CalculateSolutionSonarQubeRuleSetFilePath("MyKey", RuleSetGroup.CSharp);
+            ruleSetPath = testSubject.CalculateSolutionSonarQubeRuleSetFilePath("MyKey", LanguageGroup.CSharp);
 
             // Verify
             Assert.AreEqual(@"z:\folder\solution\SonarQube\MyKeyCSharp.ruleset", ruleSetPath);
@@ -191,7 +191,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             this.serviceProvider.RegisterService(typeof(IProjectSystemHelper), projectHelper);
 
             // Act + Verify
-            Exceptions.Expect<InvalidOperationException>(() => testSubject.CalculateSolutionSonarQubeRuleSetFilePath("MyKey", RuleSetGroup.CSharp));
+            Exceptions.Expect<InvalidOperationException>(() => testSubject.CalculateSolutionSonarQubeRuleSetFilePath("MyKey", LanguageGroup.CSharp));
         }
 
         [TestMethod]

--- a/src/Integration.UnitTests/Persistence/SolutionBindingSerializerTests.cs
+++ b/src/Integration.UnitTests/Persistence/SolutionBindingSerializerTests.cs
@@ -112,9 +112,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             var creds = new BasicAuthCredentials("user", "pwd".ConvertToSecureString());
             var projectKey = "MyProject Key";
             var written = new BoundSonarQubeProject(serverUri, projectKey, creds);
-            written.Profiles = new Dictionary<RuleSetGroup, ApplicableQualityProfile>();
-            written.Profiles[RuleSetGroup.VB] = new ApplicableQualityProfile { ProfileKey = "VB" };
-            written.Profiles[RuleSetGroup.CSharp] = new ApplicableQualityProfile { ProfileKey = "CS", ProfileTimestamp = DateTime.Now };
+            written.Profiles = new Dictionary<LanguageGroup, ApplicableQualityProfile>();
+            written.Profiles[LanguageGroup.VB] = new ApplicableQualityProfile { ProfileKey = "VB" };
+            written.Profiles[LanguageGroup.CSharp] = new ApplicableQualityProfile { ProfileKey = "CS", ProfileTimestamp = DateTime.Now };
 
             // Act (write)
             string output = testSubject.WriteSolutionBinding(written);
@@ -136,10 +136,10 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             Assert.AreEqual(creds.Password.ConvertToUnsecureString(), newCreds.Password.ConvertToUnsecureString());
             Assert.AreEqual(written.ServerUri, read.ServerUri);
             Assert.AreEqual(2, read.Profiles?.Count ?? 0);
-            Assert.AreEqual(written.Profiles[RuleSetGroup.VB].ProfileKey, read.Profiles[RuleSetGroup.VB].ProfileKey);
-            Assert.AreEqual(written.Profiles[RuleSetGroup.VB].ProfileTimestamp, read.Profiles[RuleSetGroup.VB].ProfileTimestamp);
-            Assert.AreEqual(written.Profiles[RuleSetGroup.CSharp].ProfileKey, read.Profiles[RuleSetGroup.CSharp].ProfileKey);
-            Assert.AreEqual(written.Profiles[RuleSetGroup.CSharp].ProfileTimestamp, read.Profiles[RuleSetGroup.CSharp].ProfileTimestamp);
+            Assert.AreEqual(written.Profiles[LanguageGroup.VB].ProfileKey, read.Profiles[LanguageGroup.VB].ProfileKey);
+            Assert.AreEqual(written.Profiles[LanguageGroup.VB].ProfileTimestamp, read.Profiles[LanguageGroup.VB].ProfileTimestamp);
+            Assert.AreEqual(written.Profiles[LanguageGroup.CSharp].ProfileKey, read.Profiles[LanguageGroup.CSharp].ProfileKey);
+            Assert.AreEqual(written.Profiles[LanguageGroup.CSharp].ProfileTimestamp, read.Profiles[LanguageGroup.CSharp].ProfileTimestamp);
             this.outputPane.AssertOutputStrings(0);
         }
 

--- a/src/Integration.UnitTests/ProfileConflicts/ConflictsManagerTests.cs
+++ b/src/Integration.UnitTests/ProfileConflicts/ConflictsManagerTests.cs
@@ -272,7 +272,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             {
                 string solutionRuleSet = rsInfoProvider.CalculateSolutionSonarQubeRuleSetFilePath(
                     this.solutionBinding.CurrentBinding.ProjectKey, 
-                    ProjectBindingOperation.GetProjectGroup(project));
+                    LanguageGroupHelper.GetProjectGroup(project));
                 this.fileSystem.RegisterFile(solutionRuleSet);
             }
         }

--- a/src/Integration.UnitTests/SanityTests.cs
+++ b/src/Integration.UnitTests/SanityTests.cs
@@ -62,10 +62,16 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
                                         "Get projects from SonarQube server");
             Assert.AreNotEqual(0, projects.Length, "No projects were returned");
 
-            // Step 2: Get quality profile export for the first project
+            // Step 2: Get quality profile for the first project
             var project = projects.FirstOrDefault();
+            QualityProfile profile = null;
+            RetryAction(() => s.TryGetQualityProfile(connection, project, SonarQubeServiceWrapper.CSharpLanguage, CancellationToken.None, out profile),
+                                        "Get quality profile from SonarQube server");
+            Assert.IsNotNull(profile, "No quality profile was returned");
+
+            // Step 3: Get quality profile export for the quality profile
             RoslynExportProfile export = null;
-            RetryAction(() => s.TryGetExportProfile(connection, project, SonarQubeServiceWrapper.CSharpLanguage, CancellationToken.None, out export),
+            RetryAction(() => s.TryGetExportProfile(connection, profile, SonarQubeServiceWrapper.CSharpLanguage, CancellationToken.None, out export),
                                         "Get quality profile export from SonarQube server");
             Assert.IsNotNull(export, "No quality profile export was returned");
 

--- a/src/Integration.UnitTests/Service/SonarQubeServiceWrapperTests.cs
+++ b/src/Integration.UnitTests/Service/SonarQubeServiceWrapperTests.cs
@@ -345,7 +345,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
                 ConnectionInformation conn = ConfigureValidConnection(testSubject, new[] { project });
 
                 // Setup test server
-                RegisterQualityProfileChangeLogValidatorValidator(testSubject);
+                RegisterQualityProfileChangeLogValidator(testSubject);
 
                 RequestHandler getProfileHandler = testSubject.RegisterRequestHandler(
                     SonarQubeServiceWrapper.CreateQualityProfileUrl(language, project),
@@ -384,7 +384,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
                 ConnectionInformation conn = ConfigureValidConnection(testSubject, new[] { project });
 
                 // Setup test server
-                RegisterQualityProfileChangeLogValidatorValidator(testSubject);
+                RegisterQualityProfileChangeLogValidator(testSubject);
 
                 RequestHandler getProfileHandler = testSubject.RegisterRequestHandler(
                     SonarQubeServiceWrapper.CreateQualityProfileUrl(language, project),
@@ -749,7 +749,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             });
         }
 
-        private static void RegisterQualityProfileChangeLogValidatorValidator(TestableSonarQubeServiceWrapper testSubject)
+        private static void RegisterQualityProfileChangeLogValidator(TestableSonarQubeServiceWrapper testSubject)
         {
             testSubject.RegisterQueryValidator(SonarQubeServiceWrapper.QualityProfileChangeLogAPI, request =>
             {

--- a/src/Integration/Binding/BindingWorkflow.cs
+++ b/src/Integration/Binding/BindingWorkflow.cs
@@ -34,12 +34,6 @@ namespace SonarLint.VisualStudio.Integration.Binding
         private readonly IProjectSystemHelper projectSystem;
         private readonly SolutionBindingOperation solutionBindingOperation;
 
-        internal readonly Dictionary<Language, RuleSetGroup> LanguageToGroupMapping = new Dictionary<Language, RuleSetGroup>
-        {
-            {Language.CSharp, RuleSetGroup.CSharp },
-            {Language.VBNET, RuleSetGroup.VB }
-        };        
-
         public BindingWorkflow(IHost host, ConnectionInformation connectionInformation, ProjectInformation project)
         {
             if (host == null)
@@ -76,25 +70,25 @@ namespace SonarLint.VisualStudio.Integration.Binding
             get;
         } = new HashSet<Project>();
 
-        public Dictionary<RuleSetGroup, RuleSet> Rulesets
+        public Dictionary<LanguageGroup, RuleSet> Rulesets
         {
             get;
-        } = new Dictionary<RuleSetGroup, RuleSet>();
+        } = new Dictionary<LanguageGroup, RuleSet>();
 
         public List<NuGetPackageInfo> NuGetPackages
         {
             get;
         } = new List<NuGetPackageInfo>();
 
-        public Dictionary<RuleSetGroup, string> SolutionRulesetPaths
+        public Dictionary<LanguageGroup, string> SolutionRulesetPaths
         {
             get;
-        } = new Dictionary<RuleSetGroup, string>();
+        } = new Dictionary<LanguageGroup, string>();
 
-        public Dictionary<RuleSetGroup, QualityProfile> QualityProfiles
+        public Dictionary<LanguageGroup, QualityProfile> QualityProfiles
         {
             get;
-        } = new Dictionary<RuleSetGroup, QualityProfile>();
+        } = new Dictionary<LanguageGroup, QualityProfile>();
 
         internal /*for testing purposes*/ bool AllNuGetPackagesInstalled
         {
@@ -345,10 +339,10 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
         #region Helpers
 
-        private RuleSetGroup LanguageToGroup(Language language)
+        private LanguageGroup LanguageToGroup(Language language)
         {
-            RuleSetGroup group;
-            if (!this.LanguageToGroupMapping.TryGetValue(language, out group))
+            LanguageGroup group = LanguageGroupHelper.GetLanguageGroup(language);
+            if (group == LanguageGroup.Unknown)
             {
                 Debug.Fail("Unsupported language: " + language);
                 throw new InvalidOperationException();

--- a/src/Integration/Binding/ISolutionRuleStore.cs
+++ b/src/Integration/Binding/ISolutionRuleStore.cs
@@ -16,14 +16,14 @@ namespace SonarLint.VisualStudio.Integration.Binding
     internal interface ISolutionRuleStore
     {
         /// <summary>
-        /// Registers a mapping of <see cref="RuleSetGroup"/> to <see cref="RuleSet"/>.
+        /// Registers a mapping of <see cref="LanguageGroup"/> to <see cref="RuleSet"/>.
         /// </summary>
         /// <param name="ruleSets">Required</param>
-        void RegisterKnownRuleSets(IDictionary<RuleSetGroup, RuleSet> ruleSets);
+        void RegisterKnownRuleSets(IDictionary<LanguageGroup, RuleSet> ruleSets);
 
         /// <summary>
-        /// Retrieves the path for the solution-level <see cref="RuleSet"/> mapped to the <see cref="RuleSetGroup"/>.
+        /// Retrieves the path for the solution-level <see cref="RuleSet"/> mapped to the <see cref="LanguageGroup"/>.
         /// </summary>
-        string GetRuleSetFilePath(RuleSetGroup group);
+        string GetRuleSetFilePath(LanguageGroup group);
     }
 }

--- a/src/Integration/Binding/ProjectBindingOperation.cs
+++ b/src/Integration/Binding/ProjectBindingOperation.cs
@@ -53,7 +53,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
         }
 
         #region State
-        internal /*for testing purposes*/ RuleSetGroup ProjectGroup { get; private set; }
+        internal /*for testing purposes*/ LanguageGroup ProjectGroup { get; private set; }
 
         internal /*for testing purposes*/ string ProjectFullPath { get; private set; }
 
@@ -115,7 +115,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
       
         private void CaptureProjectInformation()
         {
-            this.ProjectGroup = GetProjectGroup(this.initializedProject);
+            this.ProjectGroup = LanguageGroupHelper.GetProjectGroup(this.initializedProject);
             this.ProjectFullPath = this.initializedProject.FullName;
         }
 
@@ -191,14 +191,6 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
             public string NewRuleSetFilePath { get; set; }
 
-        }
-        #endregion
-
-        #region Static helpers
-        public static RuleSetGroup GetProjectGroup(Project project)
-        {
-            Debug.Assert(Integration.ProjectSystemHelper.IsCSharpProject(project) || Integration.ProjectSystemHelper.IsVBProject(project), "Unexpected project kind");
-            return Integration.ProjectSystemHelper.IsCSharpProject(project) ? RuleSetGroup.CSharp : RuleSetGroup.VB;
         }
         #endregion
     }

--- a/src/Integration/Binding/SolutionBindingOperation.cs
+++ b/src/Integration/Binding/SolutionBindingOperation.cs
@@ -28,7 +28,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
         private readonly IProjectSystemHelper projectSystem;
         private readonly List<IBindingOperation> childBinder = new List<IBindingOperation>();
         private readonly Dictionary<LanguageGroup, RuleSetInformation> ruleSetsInformationMap = new Dictionary<LanguageGroup, RuleSetInformation>();
-        private readonly Dictionary<LanguageGroup, QualityProfile> qualityProfileMap = new Dictionary<LanguageGroup, QualityProfile>();
+        private Dictionary<LanguageGroup, QualityProfile> qualityProfileMap;
         private readonly ConnectionInformation connection;
         private readonly string sonarQubeProjectKey;
 
@@ -116,7 +116,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
         #endregion
 
         #region Public API
-        public void Initialize(IEnumerable<Project> projects, Dictionary<LanguageGroup, QualityProfile> profilesMap)
+        public void Initialize(IEnumerable<Project> projects, IDictionary<LanguageGroup, QualityProfile> profilesMap)
         {
             if (projects == null)
             {
@@ -130,7 +130,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
             this.SolutionFullPath = this.projectSystem.GetCurrentActiveSolution().FullName;
 
-            profilesMap.ToList().ForEach(kv => qualityProfileMap.Add(kv.Key, kv.Value));
+            this.qualityProfileMap = new Dictionary<LanguageGroup, QualityProfile>(profilesMap);
 
             foreach (Project project in projects)
             {
@@ -214,6 +214,8 @@ namespace SonarLint.VisualStudio.Integration.Binding
         /// </summary>
         private void PendBindingInformation(ConnectionInformation connInfo)
         {
+            Debug.Assert(this.qualityProfileMap != null, "Initialize was expected to be called first");
+
             var binding = this.serviceProvider.GetService<ISolutionBindingSerializer>();
             binding.AssertLocalServiceIsNotNull();
 

--- a/src/Integration/Binding/SolutionBindingOperation.cs
+++ b/src/Integration/Binding/SolutionBindingOperation.cs
@@ -27,8 +27,8 @@ namespace SonarLint.VisualStudio.Integration.Binding
         private readonly ISourceControlledFileSystem sourceControlledFileSystem;
         private readonly IProjectSystemHelper projectSystem;
         private readonly List<IBindingOperation> childBinder = new List<IBindingOperation>();
-        private readonly Dictionary<RuleSetGroup, RuleSetInformation> ruleSetsInformationMap = new Dictionary<RuleSetGroup, RuleSetInformation>();
-        private readonly Dictionary<RuleSetGroup, QualityProfile> qualityProfileMap = new Dictionary<RuleSetGroup, QualityProfile>();
+        private readonly Dictionary<LanguageGroup, RuleSetInformation> ruleSetsInformationMap = new Dictionary<LanguageGroup, RuleSetInformation>();
+        private readonly Dictionary<LanguageGroup, QualityProfile> qualityProfileMap = new Dictionary<LanguageGroup, QualityProfile>();
         private readonly ConnectionInformation connection;
         private readonly string sonarQubeProjectKey;
 
@@ -72,7 +72,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
             private set;
         }
 
-        internal /*for testing purposes*/ IReadOnlyDictionary<RuleSetGroup, RuleSetInformation> RuleSetsInformationMap
+        internal /*for testing purposes*/ IReadOnlyDictionary<LanguageGroup, RuleSetInformation> RuleSetsInformationMap
         {
             get { return this.ruleSetsInformationMap; }
         }
@@ -80,7 +80,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
         #region ISolutionRuleStore
 
-        public void RegisterKnownRuleSets(IDictionary<RuleSetGroup, RuleSet> ruleSets)
+        public void RegisterKnownRuleSets(IDictionary<LanguageGroup, RuleSet> ruleSets)
         {
             if (ruleSets == null)
             {
@@ -99,7 +99,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
             }
         }
 
-        public string GetRuleSetFilePath(RuleSetGroup group)
+        public string GetRuleSetFilePath(LanguageGroup group)
         {
             RuleSetInformation info;
 
@@ -116,7 +116,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
         #endregion
 
         #region Public API
-        public void Initialize(IEnumerable<Project> projects, Dictionary<RuleSetGroup, QualityProfile> profilesMap)
+        public void Initialize(IEnumerable<Project> projects, Dictionary<LanguageGroup, QualityProfile> profilesMap)
         {
             if (projects == null)
             {
@@ -219,7 +219,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
 
             BasicAuthCredentials credentials = connection.UserName == null ? null : new BasicAuthCredentials(connInfo.UserName, connInfo.Password);
 
-            Dictionary<RuleSetGroup, ApplicableQualityProfile> map = new Dictionary<RuleSetGroup, ApplicableQualityProfile>();
+            Dictionary<LanguageGroup, ApplicableQualityProfile> map = new Dictionary<LanguageGroup, ApplicableQualityProfile>();
 
             foreach(var keyValue in this.qualityProfileMap)
             {
@@ -260,7 +260,7 @@ namespace SonarLint.VisualStudio.Integration.Binding
         /// </summary>
         internal class RuleSetInformation
         {
-            public RuleSetInformation(RuleSetGroup group, RuleSet ruleSet)
+            public RuleSetInformation(LanguageGroup group, RuleSet ruleSet)
             {
                 if (ruleSet == null)
                 {

--- a/src/Integration/Integration.csproj
+++ b/src/Integration/Integration.csproj
@@ -119,6 +119,7 @@
     <Compile Include="MefServices\IProjectPropertyManager.cs" />
     <Compile Include="MefServices\IInfoBar.cs" />
     <Compile Include="MefServices\IInfoBarManager.cs" />
+    <Compile Include="Persistence\ApplicableQualityProfile.cs" />
     <Compile Include="Persistence\BoundSonarQubeProjectExtensions.cs" />
     <Compile Include="ProfileConflicts\FixedRuleSetInfo.cs" />
     <Compile Include="LocalServices\ILocalService.cs" />
@@ -163,6 +164,8 @@
     <Compile Include="RuleSetHelper.cs" />
     <Compile Include="Language.cs" />
     <Compile Include="LocalServices\ProjectSystemFilter.cs" />
+    <Compile Include="Service\DataModel\QualityProfileChangeLog.cs" />
+    <Compile Include="Service\DataModel\QualityProfileChangeLogEvent.cs" />
     <Compile Include="Service\DataModel\ServerPlugin.cs" />
     <Compile Include="Service\DataModel\ServerProperty.cs" />
     <Compile Include="Service\RoslynExporter\AdditionalFile.cs" />

--- a/src/Integration/Integration.csproj
+++ b/src/Integration/Integration.csproj
@@ -128,7 +128,7 @@
     <Compile Include="Binding\ProjectBindingOperation.cs" />
     <Compile Include="Binding\ProjectBindingOperation.Writer.cs" />
     <Compile Include="MefServices\ProjectPropertyManager.cs" />
-    <Compile Include="RuleSetGroup.cs" />
+    <Compile Include="LanguageGroup.cs" />
     <Compile Include="ProfileConflicts\ConflictsManager.cs" />
     <Compile Include="ProfileConflicts\IConflictsManager.cs" />
     <Compile Include="ProfileConflicts\IRuleSetConflictsController.cs" />
@@ -161,6 +161,7 @@
     <Compile Include="Persistence\ISolutionBindingSerializer.cs" />
     <Compile Include="Progress\IProgressStepRunnerWrapper.cs" />
     <Compile Include="ProfileConflicts\RuleSetConflictsController.cs" />
+    <Compile Include="LanguageGroupHelper.cs" />
     <Compile Include="RuleSetHelper.cs" />
     <Compile Include="Language.cs" />
     <Compile Include="LocalServices\ProjectSystemFilter.cs" />

--- a/src/Integration/LanguageGroup.cs
+++ b/src/Integration/LanguageGroup.cs
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------
-// <copyright file="RuleSetGroup.cs" company="SonarSource SA and Microsoft Corporation">
+// <copyright file="LanguageGroup.cs" company="SonarSource SA and Microsoft Corporation">
 //   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
 //   Licensed under the MIT License. See License.txt in the project root for license information.
 // </copyright>
@@ -7,8 +7,9 @@
 
 namespace SonarLint.VisualStudio.Integration
 {
-    public enum RuleSetGroup
+    public enum LanguageGroup
     {
+        Unknown,
         CSharp,
         VB
     }

--- a/src/Integration/LanguageGroupHelper.cs
+++ b/src/Integration/LanguageGroupHelper.cs
@@ -1,0 +1,65 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="LanguageGroupHelper.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using EnvDTE;
+using System;
+using System.Diagnostics;
+
+namespace SonarLint.VisualStudio.Integration
+{
+    internal static class LanguageGroupHelper
+    {
+        public static Language GerLanguage(LanguageGroup group)
+        {
+            switch(group)
+            {
+                case LanguageGroup.CSharp:
+                    return Language.CSharp;
+
+                case LanguageGroup.VB:
+                    return Language.VBNET;
+
+                case LanguageGroup.Unknown:
+                    return Language.Unknown;
+
+                default:
+                    Debug.Fail("Unexpected group: " + group);
+                    throw new InvalidOperationException();
+            }
+        }
+
+        public static LanguageGroup GetLanguageGroup(Language language)
+        {
+            if (language == Language.CSharp)
+            {
+                return LanguageGroup.CSharp;
+            }
+
+            if (language == Language.VBNET)
+            {
+                return LanguageGroup.VB;
+            }
+
+            return LanguageGroup.Unknown;
+        }
+
+        public static LanguageGroup GetProjectGroup(Project project)
+        {
+            if (ProjectSystemHelper.IsCSharpProject(project))
+            {
+                return LanguageGroup.CSharp;
+            }
+
+            if (ProjectSystemHelper.IsVBProject(project))
+            {
+                return LanguageGroup.VB;
+            }
+
+            return LanguageGroup.Unknown;
+        }
+    }
+}

--- a/src/Integration/LanguageGroupHelper.cs
+++ b/src/Integration/LanguageGroupHelper.cs
@@ -13,7 +13,7 @@ namespace SonarLint.VisualStudio.Integration
 {
     internal static class LanguageGroupHelper
     {
-        public static Language GerLanguage(LanguageGroup group)
+        public static Language GetLanguage(LanguageGroup group)
         {
             switch(group)
             {

--- a/src/Integration/LocalServices/ErrorListInfoBarController.cs
+++ b/src/Integration/LocalServices/ErrorListInfoBarController.cs
@@ -563,12 +563,12 @@ namespace SonarLint.VisualStudio.Integration
                 if (binding.Profiles == null || binding.Profiles.Count == 0)
                 {
                     // Old binding, force refresh immediately
-                    VsShellUtils.WriteToGeneralOutputPane(this.host, Strings.SonarLintProfileCheckNoProfiles);
+                    VsShellUtils.WriteToSonarLintOutputPane(this.host, Strings.SonarLintProfileCheckNoProfiles);
                     updateAction(Strings.SonarLintInfoBarOldBindingFile);
                     return;
                 }
 
-                VsShellUtils.WriteToGeneralOutputPane(this.host, Strings.SonarLintProfileCheck);
+                VsShellUtils.WriteToSonarLintOutputPane(this.host, Strings.SonarLintProfileCheck);
 
                 CancellationToken token = this.TokenSource.Token;
                 this.BackgroundTask = System.Threading.Tasks.Task.Run(() =>
@@ -593,15 +593,15 @@ namespace SonarLint.VisualStudio.Integration
 
                 ConnectionInformation connection = binding.CreateConnectionInformation();
                 Dictionary<LanguageGroup, QualityProfile> newProfiles;
-                if (!this.TryGetNewProfiles(binding, projectLanguageGroups, token, connection, out newProfiles))
+                if (!this.TryGetLatestProfiles(binding, projectLanguageGroups, token, connection, out newProfiles))
                 {
-                    VsShellUtils.WriteToGeneralOutputPane(this.host, Strings.SonarLintProfileCheckFailed);
+                    VsShellUtils.WriteToSonarLintOutputPane(this.host, Strings.SonarLintProfileCheckFailed);
                     return false; // Error, can't proceed
                 }
 
                 if (!newProfiles.Keys.All(binding.Profiles.ContainsKey))
                 {
-                    VsShellUtils.WriteToGeneralOutputPane(this.host, Strings.SonarLintProfileCheckSolutionRequiresMoreProfiles);
+                    VsShellUtils.WriteToSonarLintOutputPane(this.host, Strings.SonarLintProfileCheckSolutionRequiresMoreProfiles);
                     return true; // Missing profile, refresh
                 }
 
@@ -623,7 +623,7 @@ namespace SonarLint.VisualStudio.Integration
                     }
                 }
 
-                VsShellUtils.WriteToGeneralOutputPane(this.host, Strings.SonarLintProfileCheckQualityProfileIsUpToDate);
+                VsShellUtils.WriteToSonarLintOutputPane(this.host, Strings.SonarLintProfileCheckQualityProfileIsUpToDate);
                 return false; // Up-to-date
             }
 
@@ -631,20 +631,20 @@ namespace SonarLint.VisualStudio.Integration
             {
                 if (!QualityProfile.KeyComparer.Equals(oldProfileInfo.ProfileKey, newProfileInfo.Key))
                 {
-                    VsShellUtils.WriteToGeneralOutputPane(this.host, Strings.SonarLintProfileCheckDifferentProfile);
+                    VsShellUtils.WriteToSonarLintOutputPane(this.host, Strings.SonarLintProfileCheckDifferentProfile);
                     return true; // The profile change to a different one
                 }
 
                 if (oldProfileInfo.ProfileTimestamp != newProfileInfo.QualityProfileTimestamp)
                 {
-                    VsShellUtils.WriteToGeneralOutputPane(this.host, Strings.SonarLintProfileCheckProfileUpdated);
+                    VsShellUtils.WriteToSonarLintOutputPane(this.host, Strings.SonarLintProfileCheckProfileUpdated);
                     return true; // The profile was updated
                 }
 
                 return false;
             }
 
-            private bool TryGetNewProfiles(BoundSonarQubeProject binding, IEnumerable<LanguageGroup> projectLanguageGroups, CancellationToken token, ConnectionInformation connection, out Dictionary<LanguageGroup, QualityProfile> newProfiles)
+            private bool TryGetLatestProfiles(BoundSonarQubeProject binding, IEnumerable<LanguageGroup> projectLanguageGroups, CancellationToken token, ConnectionInformation connection, out Dictionary<LanguageGroup, QualityProfile> newProfiles)
             {
                 newProfiles = new Dictionary<LanguageGroup, QualityProfile>();
                 foreach (LanguageGroup group in projectLanguageGroups)

--- a/src/Integration/LocalServices/ISolutionRuleSetsInformationProvider.cs
+++ b/src/Integration/LocalServices/ISolutionRuleSetsInformationProvider.cs
@@ -26,7 +26,7 @@ namespace SonarLint.VisualStudio.Integration
         /// <param name="sonarQubeProjectKey">Required</param>
         /// <param name="ruleSetGroup">The logical group of RuleSets that the solution RuleSet is created for</param>
         /// <returns>Full file path. The file may not actually exist on disk</returns>
-        string CalculateSolutionSonarQubeRuleSetFilePath(string sonarQubeProjectKey, RuleSetGroup ruleSetGroup);
+        string CalculateSolutionSonarQubeRuleSetFilePath(string sonarQubeProjectKey, LanguageGroup ruleSetGroup);
 
         /// <summary>
         /// Will return a calculated file path to the expected project RuleSet 

--- a/src/Integration/LocalServices/SolutionBindingInformationProvider.cs
+++ b/src/Integration/LocalServices/SolutionBindingInformationProvider.cs
@@ -128,7 +128,7 @@ namespace SonarLint.VisualStudio.Integration
 
             string expectedSolutionRuleSet = ruleSetInfoProvider.CalculateSolutionSonarQubeRuleSetFilePath(
                          binding.ProjectKey,
-                         ProjectBindingOperation.GetProjectGroup(project));
+                         LanguageGroupHelper.GetProjectGroup(project));
 
             RuleSet solutionRuleSet;
             if (!cache.TryGetValue(expectedSolutionRuleSet, out solutionRuleSet))

--- a/src/Integration/LocalServices/SolutionRuleSetsInformationProvider.cs
+++ b/src/Integration/LocalServices/SolutionRuleSetsInformationProvider.cs
@@ -75,7 +75,7 @@ namespace SonarLint.VisualStudio.Integration
             return ruleSetDirectoryRoot;
         }
 
-        public string CalculateSolutionSonarQubeRuleSetFilePath(string sonarQubeProjectKey, RuleSetGroup ruleSetGroup)
+        public string CalculateSolutionSonarQubeRuleSetFilePath(string sonarQubeProjectKey, LanguageGroup ruleSetGroup)
         {
             if (string.IsNullOrWhiteSpace(sonarQubeProjectKey))
             {

--- a/src/Integration/Persistence/ApplicableQualityProfile.cs
+++ b/src/Integration/Persistence/ApplicableQualityProfile.cs
@@ -1,0 +1,18 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="ApplicableQualityProfile.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+
+namespace SonarLint.VisualStudio.Integration.Persistence
+{
+    internal class ApplicableQualityProfile
+    {
+        public string ProfileKey { get; set; }
+
+        public DateTime? ProfileTimestamp { get; set; }
+    }
+}

--- a/src/Integration/Persistence/BoundSonarQubeProject.cs
+++ b/src/Integration/Persistence/BoundSonarQubeProject.cs
@@ -39,7 +39,7 @@ namespace SonarLint.VisualStudio.Integration.Persistence
 
         public string ProjectKey { get; set; }
 
-        public Dictionary<RuleSetGroup, ApplicableQualityProfile> Profiles { get; set; }
+        public Dictionary<LanguageGroup, ApplicableQualityProfile> Profiles { get; set; }
 
         [JsonIgnore]
         public ICredentials Credentials { get; set; }

--- a/src/Integration/Persistence/BoundSonarQubeProject.cs
+++ b/src/Integration/Persistence/BoundSonarQubeProject.cs
@@ -7,6 +7,7 @@
 
 using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 
 namespace SonarLint.VisualStudio.Integration.Persistence
 {
@@ -37,6 +38,8 @@ namespace SonarLint.VisualStudio.Integration.Persistence
         public Uri ServerUri { get; set; }
 
         public string ProjectKey { get; set; }
+
+        public Dictionary<RuleSetGroup, ApplicableQualityProfile> Profiles { get; set; }
 
         [JsonIgnore]
         public ICredentials Credentials { get; set; }

--- a/src/Integration/ProfileConflicts/ConflictsManager.cs
+++ b/src/Integration/ProfileConflicts/ConflictsManager.cs
@@ -112,7 +112,7 @@ namespace SonarLint.VisualStudio.Integration.ProfileConflicts
             {
                 string baselineRuleSet = ruleSetInfoProvider.CalculateSolutionSonarQubeRuleSetFilePath(
                     bindingInfo.ProjectKey, 
-                    ProjectBindingOperation.GetProjectGroup(project));
+                    LanguageGroupHelper.GetProjectGroup(project));
 
                 if (!fileSystem.FileExist(baselineRuleSet))
                 {

--- a/src/Integration/Resources/Strings.Designer.cs
+++ b/src/Integration/Resources/Strings.Designer.cs
@@ -928,6 +928,69 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to SonarLint: Checking if SonarQube Quality profile has changed..
+        /// </summary>
+        public static string SonarLintProfileCheck {
+            get {
+                return ResourceManager.GetString("SonarLintProfileCheck", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SonarLint: The SonarQube project is using a different Quality Profile. Update is required..
+        /// </summary>
+        public static string SonarLintProfileCheckDifferentProfile {
+            get {
+                return ResourceManager.GetString("SonarLintProfileCheckDifferentProfile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SonarLint: Unexpected failure getting quality profile information. Automatic quality profile update will not be performed..
+        /// </summary>
+        public static string SonarLintProfileCheckFailed {
+            get {
+                return ResourceManager.GetString("SonarLintProfileCheckFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SonarLint: The binding information is out of date. Update is required..
+        /// </summary>
+        public static string SonarLintProfileCheckNoProfiles {
+            get {
+                return ResourceManager.GetString("SonarLintProfileCheckNoProfiles", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SonarLint: The Quality Profile for the SonarQube project has changed. Update is required..
+        /// </summary>
+        public static string SonarLintProfileCheckProfileUpdated {
+            get {
+                return ResourceManager.GetString("SonarLintProfileCheckProfileUpdated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SonarLint: Quality Profile is up-to-date..
+        /// </summary>
+        public static string SonarLintProfileCheckQualityProfileIsUpToDate {
+            get {
+                return ResourceManager.GetString("SonarLintProfileCheckQualityProfileIsUpToDate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SonarLint: The solution has changed and now requires additional Quality Profiles to be included. Update is required..
+        /// </summary>
+        public static string SonarLintProfileCheckSolutionRequiresMoreProfiles {
+            get {
+                return ResourceManager.GetString("SonarLintProfileCheckSolutionRequiresMoreProfiles", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to SonarQube is an open source platform to manage code quality. Connect your solution to an existing SonarQube Server to get the same issues in Visual Studio and in your SonarQube server..
         /// </summary>
         public static string SonarQubeDescription {
@@ -942,6 +1005,15 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         public static string SonarQubeName {
             get {
                 return ResourceManager.GetString("SonarQubeName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Warning failed calling &apos;{0}&apos; (http error code={1}). Some of the functionality will be reduced..
+        /// </summary>
+        public static string SonarQubeOptionalServiceFailed {
+            get {
+                return ResourceManager.GetString("SonarQubeOptionalServiceFailed", resourceCulture);
             }
         }
         

--- a/src/Integration/Resources/Strings.Designer.cs
+++ b/src/Integration/Resources/Strings.Designer.cs
@@ -865,7 +865,16 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to One or more rule sets are out of date or not linked to the SonarQube quality profile rule set. See output window (SonarLint) for affected projects..
+        ///   Looks up a localized string similar to SonarLint can now tell you when the quality profile in SonarQube profject is updated. Press Update to enable this feature now..
+        /// </summary>
+        public static string SonarLintInfoBarOldBindingFile {
+            get {
+                return ResourceManager.GetString("SonarLintInfoBarOldBindingFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SonarLint: One or more rule sets are out of date or not linked to the SonarQube quality profile rule set (see General Output for affected projects).
         /// </summary>
         public static string SonarLintInfoBarUnboundProjectsMessage {
             get {

--- a/src/Integration/Resources/Strings.Designer.cs
+++ b/src/Integration/Resources/Strings.Designer.cs
@@ -874,7 +874,7 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to SonarLint: One or more rule sets are out of date or not linked to the SonarQube quality profile rule set (see General Output for affected projects).
+        ///   Looks up a localized string similar to One or more rule sets are out of date or not linked to the SonarQube quality profile rule set. See output window (SonarLint) for affected projects..
         /// </summary>
         public static string SonarLintInfoBarUnboundProjectsMessage {
             get {
@@ -937,7 +937,7 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to SonarLint: Checking if SonarQube Quality profile has changed..
+        ///   Looks up a localized string similar to Checking if SonarQube Quality profile has changed..
         /// </summary>
         public static string SonarLintProfileCheck {
             get {
@@ -946,7 +946,7 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to SonarLint: The SonarQube project is using a different Quality Profile. Update is required..
+        ///   Looks up a localized string similar to The SonarQube project is using a different Quality Profile. Update is required..
         /// </summary>
         public static string SonarLintProfileCheckDifferentProfile {
             get {
@@ -955,7 +955,7 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to SonarLint: Unexpected failure getting quality profile information. Automatic quality profile update will not be performed..
+        ///   Looks up a localized string similar to Unexpected failure getting quality profile information. Automatic quality profile update will not be performed..
         /// </summary>
         public static string SonarLintProfileCheckFailed {
             get {
@@ -964,7 +964,7 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to SonarLint: The binding information is out of date. Update is required..
+        ///   Looks up a localized string similar to The binding information is out of date. Update is required..
         /// </summary>
         public static string SonarLintProfileCheckNoProfiles {
             get {
@@ -973,7 +973,7 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to SonarLint: The Quality Profile for the SonarQube project has changed. Update is required..
+        ///   Looks up a localized string similar to The Quality Profile for the SonarQube project has changed. Update is required..
         /// </summary>
         public static string SonarLintProfileCheckProfileUpdated {
             get {
@@ -982,7 +982,7 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to SonarLint: Quality Profile is up-to-date..
+        ///   Looks up a localized string similar to Quality Profile is up-to-date..
         /// </summary>
         public static string SonarLintProfileCheckQualityProfileIsUpToDate {
             get {
@@ -991,7 +991,7 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to SonarLint: The solution has changed and now requires additional Quality Profiles to be included. Update is required..
+        ///   Looks up a localized string similar to The solution has changed and now requires additional Quality Profiles to be included. Update is required..
         /// </summary>
         public static string SonarLintProfileCheckSolutionRequiresMoreProfiles {
             get {

--- a/src/Integration/Resources/Strings.resx
+++ b/src/Integration/Resources/Strings.resx
@@ -640,4 +640,8 @@ This is the general format to use when writing errors to output window or when t
     <value>SonarLint: The solution has changed and now requires additional Quality Profiles to be included. Update is required.</value>
     <comment>Ouput window message</comment>
   </data>
+  <data name="SonarLintInfoBarOldBindingFile" xml:space="preserve">
+    <value>SonarLint can now tell you when the quality profile in SonarQube profject is updated. Press Update to enable this feature now.</value>
+    <comment>Info bar message</comment>
+  </data>
 </root>

--- a/src/Integration/Resources/Strings.resx
+++ b/src/Integration/Resources/Strings.resx
@@ -606,4 +606,38 @@ This is the general format to use when writing errors to output window or when t
     <value>SonarLint</value>
     <comment>Output pane title</comment>
   </data>
+  <data name="SonarQubeOptionalServiceFailed" xml:space="preserve">
+    <value>Warning failed calling '{0}' (http error code={1}). Some of the functionality will be reduced.</value>
+    <comment>Output window message. 
+{0} - service
+{1} - http error code</comment>
+  </data>
+  <data name="SonarLintProfileCheck" xml:space="preserve">
+    <value>SonarLint: Checking if SonarQube Quality profile has changed.</value>
+    <comment>Ouput window message</comment>
+  </data>
+  <data name="SonarLintProfileCheckDifferentProfile" xml:space="preserve">
+    <value>SonarLint: The SonarQube project is using a different Quality Profile. Update is required.</value>
+    <comment>Ouput window message</comment>
+  </data>
+  <data name="SonarLintProfileCheckFailed" xml:space="preserve">
+    <value>SonarLint: Unexpected failure getting quality profile information. Automatic quality profile update will not be performed.</value>
+    <comment>Ouput window message</comment>
+  </data>
+  <data name="SonarLintProfileCheckNoProfiles" xml:space="preserve">
+    <value>SonarLint: The binding information is out of date. Update is required.</value>
+    <comment>Ouput window message</comment>
+  </data>
+  <data name="SonarLintProfileCheckProfileUpdated" xml:space="preserve">
+    <value>SonarLint: The Quality Profile for the SonarQube project has changed. Update is required.</value>
+    <comment>Ouput window message</comment>
+  </data>
+  <data name="SonarLintProfileCheckQualityProfileIsUpToDate" xml:space="preserve">
+    <value>SonarLint: Quality Profile is up-to-date.</value>
+    <comment>Ouput window message</comment>
+  </data>
+  <data name="SonarLintProfileCheckSolutionRequiresMoreProfiles" xml:space="preserve">
+    <value>SonarLint: The solution has changed and now requires additional Quality Profiles to be included. Update is required.</value>
+    <comment>Ouput window message</comment>
+  </data>
 </root>

--- a/src/Integration/Resources/Strings.resx
+++ b/src/Integration/Resources/Strings.resx
@@ -613,31 +613,31 @@ This is the general format to use when writing errors to output window or when t
 {1} - http error code</comment>
   </data>
   <data name="SonarLintProfileCheck" xml:space="preserve">
-    <value>SonarLint: Checking if SonarQube Quality profile has changed.</value>
+    <value>Checking if SonarQube Quality profile has changed.</value>
     <comment>Ouput window message</comment>
   </data>
   <data name="SonarLintProfileCheckDifferentProfile" xml:space="preserve">
-    <value>SonarLint: The SonarQube project is using a different Quality Profile. Update is required.</value>
+    <value>The SonarQube project is using a different Quality Profile. Update is required.</value>
     <comment>Ouput window message</comment>
   </data>
   <data name="SonarLintProfileCheckFailed" xml:space="preserve">
-    <value>SonarLint: Unexpected failure getting quality profile information. Automatic quality profile update will not be performed.</value>
+    <value>Unexpected failure getting quality profile information. Automatic quality profile update will not be performed.</value>
     <comment>Ouput window message</comment>
   </data>
   <data name="SonarLintProfileCheckNoProfiles" xml:space="preserve">
-    <value>SonarLint: The binding information is out of date. Update is required.</value>
+    <value>The binding information is out of date. Update is required.</value>
     <comment>Ouput window message</comment>
   </data>
   <data name="SonarLintProfileCheckProfileUpdated" xml:space="preserve">
-    <value>SonarLint: The Quality Profile for the SonarQube project has changed. Update is required.</value>
+    <value>The Quality Profile for the SonarQube project has changed. Update is required.</value>
     <comment>Ouput window message</comment>
   </data>
   <data name="SonarLintProfileCheckQualityProfileIsUpToDate" xml:space="preserve">
-    <value>SonarLint: Quality Profile is up-to-date.</value>
+    <value>Quality Profile is up-to-date.</value>
     <comment>Ouput window message</comment>
   </data>
   <data name="SonarLintProfileCheckSolutionRequiresMoreProfiles" xml:space="preserve">
-    <value>SonarLint: The solution has changed and now requires additional Quality Profiles to be included. Update is required.</value>
+    <value>The solution has changed and now requires additional Quality Profiles to be included. Update is required.</value>
     <comment>Ouput window message</comment>
   </data>
   <data name="SonarLintInfoBarOldBindingFile" xml:space="preserve">

--- a/src/Integration/Service/DataModel/QualityProfile.cs
+++ b/src/Integration/Service/DataModel/QualityProfile.cs
@@ -14,6 +14,9 @@ namespace SonarLint.VisualStudio.Integration.Service
     [DebuggerDisplay("Name: {Name}, Key: {Key}, Language: {Language}, IsDefault: {IsDefault}")]
     internal class QualityProfile
     {
+        // Ordinal comparer, similar to project key comparer
+        public static readonly StringComparer KeyComparer = StringComparer.Ordinal;
+
         [JsonProperty("key")]
         public string Key { get; set; }
 

--- a/src/Integration/Service/DataModel/QualityProfile.cs
+++ b/src/Integration/Service/DataModel/QualityProfile.cs
@@ -6,9 +6,10 @@
 //-----------------------------------------------------------------------
 
 using Newtonsoft.Json;
+using System;
 using System.Diagnostics;
 
-namespace SonarLint.VisualStudio.Integration.Service.DataModel
+namespace SonarLint.VisualStudio.Integration.Service
 {
     [DebuggerDisplay("Name: {Name}, Key: {Key}, Language: {Language}, IsDefault: {IsDefault}")]
     internal class QualityProfile
@@ -24,5 +25,9 @@ namespace SonarLint.VisualStudio.Integration.Service.DataModel
 
         [JsonProperty("default")]
         public bool IsDefault { get; set; }
+
+        [JsonIgnore] // Not set by JSON
+        public DateTime? QualityProfileTimestamp { get; set; }
+
     }
 }

--- a/src/Integration/Service/DataModel/QualityProfileChangeLog.cs
+++ b/src/Integration/Service/DataModel/QualityProfileChangeLog.cs
@@ -1,0 +1,27 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="QualityProfileChangeLog.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace SonarLint.VisualStudio.Integration.Service.DataModel
+{
+    internal class QualityProfileChangeLog
+    {
+        [JsonProperty("total")]
+        public int Total { get; set; }
+
+        [JsonProperty("ps")]
+        public int PageSize { get; set; }
+
+        [JsonProperty("p")]
+        public int Page { get; set; }
+
+        [JsonProperty("events")]
+        public QualityProfileChangeLogEvent[] Events { get; set; }
+    }
+}

--- a/src/Integration/Service/DataModel/QualityProfileChangeLogEvent.cs
+++ b/src/Integration/Service/DataModel/QualityProfileChangeLogEvent.cs
@@ -1,0 +1,18 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="QualityProfileChangeLogEvent.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Newtonsoft.Json;
+using System;
+
+namespace SonarLint.VisualStudio.Integration.Service.DataModel
+{
+    internal class QualityProfileChangeLogEvent
+    {
+        [JsonProperty("date")]
+        public DateTime Date { get; set; }
+    }
+}

--- a/src/Integration/Service/ISonarQubeServiceWrapper.cs
+++ b/src/Integration/Service/ISonarQubeServiceWrapper.cs
@@ -27,21 +27,28 @@ namespace SonarLint.VisualStudio.Integration.Service
         bool TryGetProperties(ConnectionInformation serverConnection, CancellationToken token, out ServerProperty[] properties);
 
         /// <summary>
-        /// Retrieves the server's Roslyn Quality Profile export for the specified project and language
+        /// Retrieves the server's Roslyn Quality Profile export for the specified profile and language
         /// </summary>
         /// <remarks>
         /// The export contains everything required to configure the solution to match the SonarQube server analysis,
         /// including: the Code Analysis rule set, analyzer NuGet packages, and any other additional files for the analyzers.
         /// </remarks>
-        /// <param name="project">Required project information for which to retrieve the export</param>
+        /// <param name="profile">Quality profile. Required.</param>
         /// <param name="language">Language scope. Required.</param>
-        bool TryGetExportProfile(ConnectionInformation serverConnection, ProjectInformation project, string language, CancellationToken token, out RoslynExportProfile profile);
+        bool TryGetExportProfile(ConnectionInformation serverConnection, QualityProfile profile, string language, CancellationToken token, out RoslynExportProfile export);
 
         /// <summary>
         /// Retrieves all server plugins
         /// </summary>
         /// <returns>All server plugins, or null on connection failure</returns>
         bool TryGetPlugins(ConnectionInformation serverConnection, CancellationToken token, out ServerPlugin[] plugins);
+
+        /// <summary>
+        /// Retrieves the quality profile information for the specified project and language
+        /// </summary>
+        /// <param name="project">Required project information for which to retrieve the export</param>
+        /// <param name="language">Language scope. Required.</param>
+        bool TryGetQualityProfile(ConnectionInformation serverConnection, ProjectInformation project, string language, CancellationToken token, out QualityProfile profile);
 
         /// <summary>
         /// Generate a <see cref="Uri"/> to the dashboard for the given project on the provided <paramref name="serverConnection"/>.

--- a/src/Integration/Service/SonarQubeServiceWrapper.cs
+++ b/src/Integration/Service/SonarQubeServiceWrapper.cs
@@ -310,7 +310,7 @@ namespace SonarLint.VisualStudio.Integration.Service
             }
             else
             {
-                VsShellUtils.WriteToGeneralOutputPane(this.serviceProvider, Strings.SonarQubeOptionalServiceFailed, QualityProfileChangeLogAPI, (int)response.StatusCode);
+                VsShellUtils.WriteToSonarLintOutputPane(this.serviceProvider, Strings.SonarQubeOptionalServiceFailed, QualityProfileChangeLogAPI, (int)response.StatusCode);
                 return null;
             }
         }

--- a/src/SonarQube/SolutionBinding.sqconfig
+++ b/src/SonarQube/SolutionBinding.sqconfig
@@ -1,4 +1,10 @@
 {
   "ServerUri": "https://dory.sonarsource.com/sonarqube/",
-  "ProjectKey": "sonarlint-visualstudio"
+  "ProjectKey": "sonarlint-visualstudio",
+  "Profiles": {
+    "CSharp": {
+      "ProfileKey": "cs-c-qp-for-sonarsource-73109",
+      "ProfileTimestamp": "2016-04-08T10:15:44+01:00"
+    }
+  }
 }

--- a/src/TestInfrastructure/Framework/ConfigurableSolutionBindingInformationProvider.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableSolutionBindingInformationProvider.cs
@@ -1,4 +1,4 @@
-//-----------------------------------------------------------------------
+﻿//-----------------------------------------------------------------------
 // <copyright file="ConfigurableSolutionBindingInformationProvider.cs" company="SonarSource SA and Microsoft Corporation">
 //   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
 //   Licensed under the MIT License. See License.txt in the project root for license information.

--- a/src/TestInfrastructure/Framework/ConfigurableSolutionBindingInformationProvider.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableSolutionBindingInformationProvider.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="ConfigurableSolutionBindingInformationProvider.cs" company="SonarSource SA and Microsoft Corporation">
 //   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
 //   Licensed under the MIT License. See License.txt in the project root for license information.
@@ -14,7 +14,9 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
     internal class ConfigurableSolutionBindingInformationProvider : ISolutionBindingInformationProvider
     {
         public IEnumerable<Project> BoundProjects { get; set; } = Enumerable.Empty<Project>();
+
         public IEnumerable<Project> UnboundProjects { get; set; } = Enumerable.Empty<Project>();
+
         public bool SolutionBound { get; set; }
 
         public IEnumerable<Project> GetBoundProjects()

--- a/src/TestInfrastructure/Framework/ConfigurableSolutionRuleSetsInformationProvider.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableSolutionRuleSetsInformationProvider.cs
@@ -35,7 +35,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             return Path.Combine(this.SolutionRootFolder, Constants.SonarQubeManagedFolderName);
         }
 
-        string ISolutionRuleSetsInformationProvider.CalculateSolutionSonarQubeRuleSetFilePath(string sonarQubeProjectKey, RuleSetGroup group)
+        string ISolutionRuleSetsInformationProvider.CalculateSolutionSonarQubeRuleSetFilePath(string sonarQubeProjectKey, LanguageGroup group)
         {
             string fileName = $"{sonarQubeProjectKey}{group}.{Constants.RuleSetFileExtension}";
             return Path.Combine(((ISolutionRuleSetsInformationProvider)this).GetSolutionSonarQubeRulesFolder(), fileName);

--- a/src/TestInfrastructure/Framework/ConfigurableSolutionRuleStore.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableSolutionRuleStore.cs
@@ -14,19 +14,19 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 {
     internal class ConfigurableSolutionRuleStore: ISolutionRuleStore
     {
-        private readonly Dictionary<RuleSetGroup, string> registeredPaths = new Dictionary<RuleSetGroup, string>();
-        private IDictionary<RuleSetGroup, RuleSet> availableRuleSets;
+        private readonly Dictionary<LanguageGroup, string> registeredPaths = new Dictionary<LanguageGroup, string>();
+        private IDictionary<LanguageGroup, RuleSet> availableRuleSets;
 
         #region ISolutionRuleStore
 
-        string ISolutionRuleStore.GetRuleSetFilePath(RuleSetGroup group)
+        string ISolutionRuleStore.GetRuleSetFilePath(LanguageGroup group)
         {
             string path;
             Assert.IsTrue(this.registeredPaths.TryGetValue(group, out path), "No path for group: " + group);
             return path;
         }
 
-        void ISolutionRuleStore.RegisterKnownRuleSets(IDictionary<RuleSetGroup, RuleSet> ruleSets)
+        void ISolutionRuleStore.RegisterKnownRuleSets(IDictionary<LanguageGroup, RuleSet> ruleSets)
         {
             Assert.IsNotNull(ruleSets, "Not expecting nulls");
 
@@ -37,7 +37,7 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
         #region Test helpers
 
-        public void RegisterRuleSetPath(RuleSetGroup group, string path)
+        public void RegisterRuleSetPath(LanguageGroup group, string path)
         {
             this.registeredPaths[group] = path;
         }

--- a/src/TestInfrastructure/Framework/ConfigurableSonarQubeServiceWrapper.cs
+++ b/src/TestInfrastructure/Framework/ConfigurableSonarQubeServiceWrapper.cs
@@ -88,6 +88,12 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             set;
         }
 
+        public string ExpectedProjectKey
+        {
+            get;
+            set;
+        }
+
         private void AssertExpectedConnection(ConnectionInformation connection)
         {
             Assert.IsNotNull(connection, "The API requires a connection information");
@@ -95,6 +101,16 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
             if (this.ExpectedConnection != null)
             {
                 Assert.AreEqual(this.ExpectedConnection?.ServerUri, connection.ServerUri, "The connection is not as expected");
+            }
+        }
+
+        private void AssertExpectedProjectInformation(ProjectInformation projectInformation)
+        {
+            Assert.IsNotNull(projectInformation, "The API requires project information");
+
+            if (this.ExpectedProjectKey != null)
+            {
+                Assert.AreEqual(this.ExpectedProjectKey, projectInformation.Key, "Unexpected project key");
             }
         }
         #endregion
@@ -171,12 +187,16 @@ namespace SonarLint.VisualStudio.Integration.UnitTests
 
         bool ISonarQubeServiceWrapper.TryGetQualityProfile(ConnectionInformation serverConnection, ProjectInformation project, string language, CancellationToken token, out QualityProfile profile)
         {
-            this.AssertExpectedConnection(serverConnection);
-
-            Assert.IsNotNull(project, "ProjectInformation is expected");
-
             profile = null;
-            this.ReturnProfile.TryGetValue(language, out profile);
+
+            if (this.AllowConnections && !token.IsCancellationRequested)
+            {
+                this.AssertExpectedConnection(serverConnection);
+
+                this.AssertExpectedProjectInformation(project);
+
+                this.ReturnProfile.TryGetValue(language, out profile);
+            }
 
             return profile != null;
         }


### PR DESCRIPTION
1. Will kick off a background task that will check if the quality profile has changed
2. Will still work on older SQ servers (<5.2) but will not perform the timestamp check since there's nothing to check.
3. If the solution closed/reopened it will call a refresh which will cancel the background task
4. Once the new sqconfig is used, opening a solution with it in a different machine (with previous version of the extension) will work as well, obviously without any update suggestions.

Misc: renamed RuleSetGroup -> LanguageGroup since its a bit more general than what it was when we started. I also moved various related helpers into a separate common class.