### PR TITLE
[SVS-21] Allow to scroll in the SonarQube projects lists when binding

### DIFF
--- a/src/Integration/TeamExplorer/CommonStyles.xaml
+++ b/src/Integration/TeamExplorer/CommonStyles.xaml
@@ -83,6 +83,17 @@
         <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="TreeView">
+                    <Border BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            SnapsToDevicePixels="True">
+                        <ItemsPresenter/>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style x:Key="SQTreeViewItemStyleBase" BasedOn="{StaticResource TreeViewItemStyle}" TargetType="TreeViewItem">

--- a/src/SonarQube/SolutionBinding.sqconfig
+++ b/src/SonarQube/SolutionBinding.sqconfig
@@ -4,7 +4,7 @@
   "Profiles": {
     "CSharp": {
       "ProfileKey": "cs-c-qp-for-sonarsource-73109",
-      "ProfileTimestamp": "2016-04-08T10:15:44+01:00"
+      "ProfileTimestamp": "2016-04-28T15:34:35+01:00"
     }
   }
 }

--- a/src/SonarQube/sonarlint-visualstudioCSharp.ruleset
+++ b/src/SonarQube/sonarlint-visualstudioCSharp.ruleset
@@ -2,51 +2,51 @@
 <RuleSet Name="Rules for SonarQube" Description="This rule set was automatically generated from SonarQube." ToolsVersion="14.0">
   <Rules AnalyzerId="SonarAnalyzer.CSharp" RuleNamespace="SonarAnalyzer.CSharp">
     <Rule Id="S100" Action="None" />
-    <Rule Id="S1006" Action="None" />
+    <Rule Id="S1006" Action="Warning" />
     <Rule Id="S101" Action="None" />
     <Rule Id="S103" Action="None" />
     <Rule Id="S104" Action="None" />
     <Rule Id="S105" Action="None" />
     <Rule Id="S1066" Action="Warning" />
-    <Rule Id="S1067" Action="Warning" />
-    <Rule Id="S107" Action="Warning" />
+    <Rule Id="S1067" Action="None" />
+    <Rule Id="S107" Action="None" />
     <Rule Id="S108" Action="Warning" />
     <Rule Id="S1109" Action="Warning" />
     <Rule Id="S1116" Action="Warning" />
     <Rule Id="S1117" Action="Warning" />
     <Rule Id="S1118" Action="Warning" />
-    <Rule Id="S1121" Action="Warning" />
-    <Rule Id="S1125" Action="Warning" />
+    <Rule Id="S1121" Action="None" />
+    <Rule Id="S1125" Action="None" />
     <Rule Id="S1134" Action="Warning" />
     <Rule Id="S1135" Action="Warning" />
-    <Rule Id="S1144" Action="None" />
+    <Rule Id="S1144" Action="Warning" />
     <Rule Id="S1145" Action="Warning" />
     <Rule Id="S1155" Action="Warning" />
     <Rule Id="S1172" Action="Warning" />
-    <Rule Id="S1185" Action="None" />
-    <Rule Id="S1186" Action="Warning" />
+    <Rule Id="S1185" Action="Warning" />
+    <Rule Id="S1186" Action="None" />
     <Rule Id="S121" Action="Warning" />
-    <Rule Id="S122" Action="Warning" />
-    <Rule Id="S1226" Action="Warning" />
+    <Rule Id="S122" Action="None" />
+    <Rule Id="S1226" Action="None" />
     <Rule Id="S1227" Action="None" />
     <Rule Id="S1244" Action="Warning" />
     <Rule Id="S125" Action="Warning" />
     <Rule Id="S126" Action="None" />
-    <Rule Id="S127" Action="Warning" />
+    <Rule Id="S127" Action="None" />
     <Rule Id="S1301" Action="Warning" />
-    <Rule Id="S131" Action="Warning" />
-    <Rule Id="S1313" Action="Warning" />
+    <Rule Id="S131" Action="None" />
+    <Rule Id="S1313" Action="None" />
     <Rule Id="S134" Action="None" />
     <Rule Id="S1449" Action="Warning" />
-    <Rule Id="S1479" Action="Warning" />
+    <Rule Id="S1479" Action="None" />
     <Rule Id="S1481" Action="Warning" />
-    <Rule Id="S1541" Action="Warning" />
+    <Rule Id="S1541" Action="None" />
     <Rule Id="S1643" Action="Warning" />
     <Rule Id="S1656" Action="Warning" />
-    <Rule Id="S1659" Action="Warning" />
+    <Rule Id="S1659" Action="None" />
     <Rule Id="S1694" Action="None" />
     <Rule Id="S1697" Action="Warning" />
-    <Rule Id="S1698" Action="None" />
+    <Rule Id="S1698" Action="Warning" />
     <Rule Id="S1699" Action="Warning" />
     <Rule Id="S1764" Action="Warning" />
     <Rule Id="S1848" Action="Warning" />
@@ -57,19 +57,19 @@
     <Rule Id="S1905" Action="Warning" />
     <Rule Id="S1939" Action="Warning" />
     <Rule Id="S1940" Action="Warning" />
-    <Rule Id="S1944" Action="None" />
-    <Rule Id="S1994" Action="Warning" />
+    <Rule Id="S1944" Action="Warning" />
+    <Rule Id="S1994" Action="None" />
     <Rule Id="S2070" Action="None" />
     <Rule Id="S2123" Action="Warning" />
-    <Rule Id="S2184" Action="None" />
+    <Rule Id="S2184" Action="Warning" />
     <Rule Id="S2197" Action="None" />
     <Rule Id="S2219" Action="Warning" />
     <Rule Id="S2223" Action="Warning" />
     <Rule Id="S2225" Action="Warning" />
-    <Rule Id="S2228" Action="Warning" />
+    <Rule Id="S2228" Action="None" />
     <Rule Id="S2234" Action="Warning" />
     <Rule Id="S2275" Action="Warning" />
-    <Rule Id="S2278" Action="None" />
+    <Rule Id="S2278" Action="Warning" />
     <Rule Id="S2290" Action="Warning" />
     <Rule Id="S2291" Action="Warning" />
     <Rule Id="S2292" Action="Warning" />
@@ -77,7 +77,7 @@
     <Rule Id="S2326" Action="Warning" />
     <Rule Id="S2328" Action="Warning" />
     <Rule Id="S2330" Action="None" />
-    <Rule Id="S2333" Action="Warning" />
+    <Rule Id="S2333" Action="None" />
     <Rule Id="S2339" Action="None" />
     <Rule Id="S2344" Action="Warning" />
     <Rule Id="S2345" Action="Warning" />
@@ -87,71 +87,71 @@
     <Rule Id="S2368" Action="Warning" />
     <Rule Id="S2372" Action="Warning" />
     <Rule Id="S2376" Action="Warning" />
-    <Rule Id="S2387" Action="Warning" />
+    <Rule Id="S2387" Action="None" />
     <Rule Id="S2437" Action="Warning" />
     <Rule Id="S2486" Action="Warning" />
-    <Rule Id="S2551" Action="Warning" />
-    <Rule Id="S2674" Action="Warning" />
+    <Rule Id="S2551" Action="None" />
+    <Rule Id="S2674" Action="None" />
     <Rule Id="S2681" Action="Warning" />
     <Rule Id="S2692" Action="Warning" />
     <Rule Id="S2696" Action="Warning" />
-    <Rule Id="S2737" Action="Warning" />
+    <Rule Id="S2737" Action="None" />
     <Rule Id="S2743" Action="Warning" />
     <Rule Id="S2757" Action="Warning" />
     <Rule Id="S2758" Action="Warning" />
     <Rule Id="S2760" Action="None" />
     <Rule Id="S2761" Action="Warning" />
     <Rule Id="S2930" Action="Warning" />
-    <Rule Id="S2931" Action="Warning" />
+    <Rule Id="S2931" Action="None" />
     <Rule Id="S2933" Action="Warning" />
     <Rule Id="S2934" Action="Warning" />
-    <Rule Id="S2952" Action="Warning" />
+    <Rule Id="S2952" Action="None" />
     <Rule Id="S2953" Action="Warning" />
-    <Rule Id="S2955" Action="Warning" />
+    <Rule Id="S2955" Action="None" />
     <Rule Id="S2971" Action="Warning" />
     <Rule Id="S2995" Action="Warning" />
     <Rule Id="S2996" Action="Warning" />
     <Rule Id="S2997" Action="Warning" />
     <Rule Id="S3005" Action="Warning" />
-    <Rule Id="S3052" Action="Warning" />
+    <Rule Id="S3052" Action="None" />
     <Rule Id="S3168" Action="Warning" />
     <Rule Id="S3169" Action="Warning" />
     <Rule Id="S3172" Action="Warning" />
-    <Rule Id="S3215" Action="Warning" />
+    <Rule Id="S3215" Action="None" />
     <Rule Id="S3216" Action="Warning" />
     <Rule Id="S3217" Action="Warning" />
     <Rule Id="S3218" Action="Warning" />
     <Rule Id="S3220" Action="Warning" />
     <Rule Id="S3234" Action="Warning" />
-    <Rule Id="S3235" Action="Warning" />
+    <Rule Id="S3235" Action="None" />
     <Rule Id="S3236" Action="Warning" />
     <Rule Id="S3237" Action="Warning" />
-    <Rule Id="S3240" Action="Warning" />
+    <Rule Id="S3240" Action="None" />
     <Rule Id="S3244" Action="Warning" />
     <Rule Id="S3246" Action="Warning" />
     <Rule Id="S3249" Action="Warning" />
-    <Rule Id="S3251" Action="None" />
-    <Rule Id="S3253" Action="Warning" />
-    <Rule Id="S3254" Action="Warning" />
+    <Rule Id="S3251" Action="Warning" />
+    <Rule Id="S3253" Action="None" />
+    <Rule Id="S3254" Action="None" />
     <Rule Id="S3257" Action="None" />
     <Rule Id="S3262" Action="Warning" />
     <Rule Id="S3263" Action="Warning" />
-    <Rule Id="S3265" Action="None" />
+    <Rule Id="S3265" Action="Warning" />
     <Rule Id="S3376" Action="Warning" />
     <Rule Id="S3397" Action="Warning" />
     <Rule Id="S3427" Action="Warning" />
     <Rule Id="S3441" Action="None" />
-    <Rule Id="S3443" Action="None" />
-    <Rule Id="S3444" Action="None" />
-    <Rule Id="S3447" Action="None" />
-    <Rule Id="S3449" Action="None" />
-    <Rule Id="S3450" Action="None" />
-    <Rule Id="S3451" Action="None" />
-    <Rule Id="S3456" Action="None" />
-    <Rule Id="S3457" Action="None" />
-    <Rule Id="S3466" Action="None" />
+    <Rule Id="S3443" Action="Warning" />
+    <Rule Id="S3444" Action="Warning" />
+    <Rule Id="S3447" Action="Warning" />
+    <Rule Id="S3449" Action="Warning" />
+    <Rule Id="S3450" Action="Warning" />
+    <Rule Id="S3451" Action="Warning" />
+    <Rule Id="S3456" Action="Warning" />
+    <Rule Id="S3457" Action="Warning" />
+    <Rule Id="S3466" Action="Warning" />
     <Rule Id="S3532" Action="None" />
-    <Rule Id="S818" Action="Warning" />
+    <Rule Id="S818" Action="None" />
     <Rule Id="S907" Action="Warning" />
     <Rule Id="S927" Action="Warning" />
   </Rules>


### PR DESCRIPTION
Use a custom control template for the tree view on the SonarQube team explorer page, which omits the `ScrollViewer` present in the default one.
This allows the mouse scroll wheel events to be first handled by the TE, rather than our control.

I also updated the binding, as prompted, because the quality profile had changed on the SQ server.