### PR TITLE
[SVS-59] Update "Username" label to "Username/Token"

### DIFF
--- a/src/Integration/Resources/Strings.Designer.cs
+++ b/src/Integration/Resources/Strings.Designer.cs
@@ -1135,7 +1135,7 @@ namespace SonarLint.VisualStudio.Integration.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Username:.
+        ///   Looks up a localized string similar to Username/Token:.
         /// </summary>
         public static string UsernameLabel {
             get {

--- a/src/Integration/Resources/Strings.resx
+++ b/src/Integration/Resources/Strings.resx
@@ -162,8 +162,8 @@
     <comment>Input label for SonarQube server URL</comment>
   </data>
   <data name="UsernameLabel" xml:space="preserve">
-    <value>Username:</value>
-    <comment>Input label for username when connecting to a SonarQube server</comment>
+    <value>Username/Token:</value>
+    <comment>Input label for username/token when connecting to a SonarQube server</comment>
   </data>
   <data name="ExceptionInsecureSchemesIsNotSubset" xml:space="preserve">
     <value>Insecure schemes must be a subset of supported schemes</value>


### PR DESCRIPTION
We also support personal access tokens (the recommended way to connect to the SQ server non-interactively). Updating the connection information dialog label.