### PR TITLE
[SVS-102] SonarLint -> SonarLint Connected Mode

### DIFF
--- a/src/Integration.Vsix/Commands/PackageCommands.vsct
+++ b/src/Integration.Vsix/Commands/PackageCommands.vsct
@@ -21,7 +21,7 @@
         <Parent guid="guidCmdSet" id="groupidProjectSonarLint"/>
         <CommandFlag>DynamicVisibility</CommandFlag>
         <Strings>
-          <ButtonText>&amp;SonarLint</ButtonText>
+          <ButtonText>&amp;SonarLint Connected Mode</ButtonText>
         </Strings>
       </Menu>
       <Menu guid="guidCmdSet" id="menuidProjectTestProperty" priority="0x200">


### PR DESCRIPTION
NB: I'm not using the exact wording/brackets in the [ticket](https://jira.sonarsource.com/browse/SVS-102)
> "SonarLint (connected mode)"

because this does not align with the phrasing/style of the rest of the VS menus.

> "SonarLint Connected Mode"

is much more appealing and consistent.